### PR TITLE
docs(work-issues): add paused label to Phase 4 label-creation list

### DIFF
--- a/plugins/work-issues/skills/work-issues/SKILL.md
+++ b/plugins/work-issues/skills/work-issues/SKILL.md
@@ -227,6 +227,8 @@ gh label create blocked --color B60205 \
   --description "Awaiting clarification before work can resume" 2>/dev/null || true
 gh label create in-progress --color FBCA04 \
   --description "A running Claude Code session is working on this issue" 2>/dev/null || true
+gh label create paused --color D4C5F9 \
+  --description "A running Claude Code session is paused on this issue (recoverable — usage cap, infra outage)" 2>/dev/null || true
 ```
 
 ## Phase 5 — Execution loop
@@ -530,7 +532,7 @@ If you hit a usage / quota cap mid-implementation (e.g. "out of extra usage · r
 
 1. Push whatever in-progress work is committable (commit the partial diff so the next agent can resume).
 2. Comment on the issue: `gh issue comment <N> --body 'Claude: Paused — usage cap, resumes <reset-time>. Branch: <branch-name>'`
-3. Apply `paused` (or `blocked` if no `paused` label exists) and remove `in-progress`:
+3. Apply `paused` and remove `in-progress`:
 
        gh issue edit <N> --add-label paused --remove-label in-progress
 


### PR DESCRIPTION
## Summary
- Phase 4 label-creation block now creates the `paused` label (color `D4C5F9` purple — distinct from `in-progress`'s `FBCA04` yellow) so it's guaranteed to exist when an agent hits a recoverable pause.
- Drops the "or `blocked` if no `paused` label exists" fallback parenthetical from the usage-cap-exhaustion bullet — the label is now guaranteed to exist after Phase 4 runs.

## Color choice
`D4C5F9` (purple) — picked because it's visually distinct from the existing three labels (`scheduled` green, `blocked` red, `in-progress` yellow) and reads as "soft hold" rather than "active work". The issue body's `FBCA04` was a copy-paste of `in-progress`'s color; using a distinct color avoids ambiguity in the GitHub label UI.

## Test plan
- [ ] Diff shows the new `gh label create paused` line in Phase 4 with a distinct color and description.
- [ ] Usage-cap-exhaustion bullet no longer has the fallback parenthetical.

Closes #25