### PR TITLE
docs(work-issues): add auto-close-failed fallback to Phase 6

### DIFF
--- a/plugins/work-issues/skills/work-issues/SKILL.md
+++ b/plugins/work-issues/skills/work-issues/SKILL.md
@@ -796,7 +796,13 @@ Return EXACTLY ONE of:
 
 When the orchestrator detects a merged PR (via Phase 5 monitoring):
 
-- Confirm the issue closed (`gh issue view <n> --json state` should report `CLOSED`).
+- Confirm the issue closed (`gh issue view <n> --json state` should report `CLOSED`). **If still OPEN, close manually:**
+
+  ```bash
+  gh issue close <n> --comment "Closed by merge of PR #<P> (squash commit <sha>). Auto-close didn't fire — closing manually."
+  ```
+
+  GitHub's auto-close-on-`Closes #N` is unreliable for App-token-mediated API merges (observed in repos using a merge-bot pattern with bypass-actor App tokens). Don't wait for it; verify and close yourself.
 - The `in-progress` label persists on the closed issue (intentional — preserves audit trail).
 - Update internal state; pick up the next eligible issue.
 


### PR DESCRIPTION
## Summary
- Phase 6's "confirm the issue closed" check now includes a fallback `gh issue close` command for the case where GitHub's auto-close-on-`Closes #N` didn't fire (common with App-token-mediated merges via merge-bot patterns).

## Test plan
- [ ] Phase 6 has the manual-close fallback verbatim from the issue.
- [ ] In-progress label persistence rule still present.

Closes #10