### PR TITLE
docs(work-issues): document Task-tool-unavailable fallback

### DIFF
--- a/plugins/work-issues/skills/work-issues/SKILL.md
+++ b/plugins/work-issues/skills/work-issues/SKILL.md
@@ -255,7 +255,7 @@ Loop until every issue is terminal (merged, parked, or excluded):
 
 4. **Monitor** — Claude Code notifies the orchestrator when each background agent completes. On notification:
    - **MERGED**: GitHub closed the issue via `Closes #<n>`. Mark task done; pick up the next eligible issue.
-   - **AUTOMERGE_SET**: agent set automerge and exited. Slot is now free — pick up the next eligible issue. The orchestrator hands off to **Phase 5b** (post-automerge monitoring): a thin shell monitor polls the PR; auto-resolves `BEHIND` in-shell; emits events that the orchestrator routes to focused mini-agents for `CONFLICT` / `CI_FAILURE` / `NEW_COMMENT`; exits on `MERGED`.
+   - **AUTOMERGE_SET**: agent set automerge and exited. Slot is now free — pick up the next eligible issue. The orchestrator hands off to **Phase 5b** (post-automerge monitoring): a thin shell monitor polls the PR; auto-resolves `BEHIND` in-shell; emits events that the orchestrator routes to focused mini-agents for `CONFLICT` / `CI_FAILURE` / `NEW_COMMENT`; exits on `MERGED`. **Review-fallback check:** if the PR body contains a `### Self-review only` section (the implementing agent's harness lacked the `Task` / `general-purpose` subagent type), dispatch a separate review subagent at the orchestrator level *before* the merge lands. Use the same review prompt the dispatch template's 6.1 would have used and treat its output as a normal review pass — any findings flow back to the PR via inline `Claude Reviewer: ` comments and the Phase 5b monitor's `NEW_COMMENT` event will route them to the review-comment mini-agent.
    - **BLOCKED**: ensure `blocked` label set, `in-progress` removed; record the question for batched surfacing in Phase 7.
    - **PAUSED**: ensure `paused` (or `blocked`) label is set; record the reset time. Re-dispatch a resumption agent (Phase 5 step 0 path) after the condition clears.
    - **ERRORED**: surface immediately to user; do not retry without instruction.
@@ -411,6 +411,8 @@ Spawn ONE Agent (subagent_type: general-purpose, run_in_background: false) to re
   >     -f line=<line>
   >
   > Use the `Claude Reviewer: ` prefix on every comment. If the diff is clean (no findings), post a single PR comment via `gh pr comment <pr#> --body 'Claude Reviewer: LGTM. <one-line summary of what you checked>'` and return.
+
+**Fallback if the `Task` / `general-purpose` subagent type is unavailable in your harness.** Do NOT skip review. Self-review the diff against the same checklist the subagent would use (scope creep, undocumented decisions, missing tests, dead code, unclear naming, breaking changes that aren't called out, security issues, convention violations) and add a `### Self-review only` section to the PR body explicitly stating the subagent was unavailable and listing what you checked. Then proceed to 6.2 normally and return `AUTOMERGE_SET` as normal — the orchestrator's Phase 5 monitoring greps for `### Self-review only` and dispatches a review subagent at its own level to fill the gap.
 
 Wait for it to complete. **When it returns, do NOT report its findings back to the orchestrator — proceed immediately to 6.2.**
 


### PR DESCRIPTION
## Summary
- Sub-step 6.1 now prescribes a self-review fallback when the Task subagent type is unavailable: agent reviews against the same checklist and adds a `### Self-review only` section to the PR body.
- Phase 5 step 4's AUTOMERGE_SET handler now greps for `### Self-review only` and dispatches an orchestrator-level review subagent if present.

Adapted to current `AUTOMERGE_SET` contract (issue body referenced the older `MERGED-PENDING`).

## Test plan
- [ ] 6.1 has the fallback paragraph using `AUTOMERGE_SET`.
- [ ] Phase 5 has the orchestrator-side review-fallback dispatch.
- [ ] The literal string `### Self-review only` appears in both sites.

### Self-review only
The `Task` / `general-purpose` subagent type was unavailable in this harness, so the implementing agent self-reviewed per the new 6.1 fallback (which this PR introduces). Checked against the standard 6.1 checklist:

- **Scope creep**: none — two textual additions matching the issue's acceptance criteria exactly.
- **Undocumented decisions**: `MERGED-PENDING` → `AUTOMERGE_SET` adaptation noted in the issue's framing preamble and in the PR Summary above.
- **Missing tests**: N/A — docs-only change to a SKILL.md prompt template.
- **Dead code**: none.
- **Unclear naming**: `### Self-review only` section name is verbatim from the issue and used identically in both sites.
- **Breaking changes**: none — additive guidance for a previously-undefined failure case.
- **Convention compliance**: conventional commit, `Closes #9` footer, prose matches the existing file voice.
- **Integration sanity**: the Phase 5 fallback routes findings through the existing `NEW_COMMENT` mini-agent path so the review-fallback hooks into Phase 5b without inventing a new code path.

Per the new orchestrator-side fallback this PR documents, the orchestrator should dispatch a review subagent at its own level before the merge lands.

Closes #9