### PR TITLE
docs(work-issues): add terminal-string discipline to dispatch template

### DIFF
--- a/plugins/work-issues/skills/work-issues/SKILL.md
+++ b/plugins/work-issues/skills/work-issues/SKILL.md
@@ -616,6 +616,14 @@ Return EXACTLY ONE of these strings, ONCE, at the very end. Do not narrate progr
 - `PAUSED <N> <reason>` — environmentally paused (usage cap, infra outage). Orchestrator may re-dispatch when the condition clears.
 - `ERRORED <N> <error>` — non-recoverable failure.
 
+### Returning your terminal status
+
+The orchestrator parses **only** the `result` field of your final notification, and it parses by literal prefix match. Format discipline is load-bearing:
+
+- The `result` field of your final notification MUST start with one of the literal terminal tokens above (`AUTOMERGE_SET`, `MERGED`, `BLOCKED`, `PAUSED`, `ERRORED`) followed by the relevant args. No leading prose, no quoting, no markdown — the token is the first thing the orchestrator sees.
+- Heartbeat notifications during 6.1 → 6.4 (e.g. "ran review subagent", "addressed CI failure", "applied automerge label") are fine and encouraged — they let the user see progress. Only the *final* notification is the terminal handoff; only its `result` is parsed.
+- If you find yourself wanting to narrate ("the PR merged successfully, returning MERGED ..."), that's a heartbeat at best. The terminal contract is the literal token plus its args, nothing else. Freeform prose around the token breaks the orchestrator's parse and forces a manual recovery.
+
 If you find yourself thinking "the review is done, I should report back" — don't. The review is the *start* of the merge loop, not the end. If you find yourself thinking "I should poll until the PR merges" — don't. Setting automerge is the end of your job; Phase 5b owns the rest.
 ```
 


### PR DESCRIPTION
## Summary
- Adds a dedicated "Returning your terminal status" sub-section adjacent to the dispatch template's Output bullets, formalizing that the agent's final notification `result` field must start with the literal terminal token (`MERGED` / `AUTOMERGE_SET` / `BLOCKED` / `PAUSED` / `ERRORED`).
- Distinguishes terminal handoff from heartbeat notifications during 6.x.

This is the narrowed remainder from issue #20 — the over-monitor failure mode was structurally prevented by #3 / PR #8.

## Test plan
- [ ] New "Returning your terminal status" sub-section adjacent to Output.
- [ ] Heartbeat-vs-terminal distinction is explicit.
- [ ] No regressions to existing Output bullets or the bold guard.

### Self-review only

The `Task` / `general-purpose` subagent type is unavailable in this harness, so the implementing agent self-reviewed in lieu of the 6.1 review subagent. Checked:

- **Scope**: single 8-line addition matching the issue's narrowed scope; no edits to the existing Output bullet list, the bold guard at line 565, or the closing exhortation paragraph.
- **Placement**: new sub-section is adjacent to Output as the issue specified — directly after the bullet list, before the existing "If you find yourself thinking ..." paragraph (which now reads as a closing exhortation under the new section).
- **Vocabulary alignment**: literal token list (`AUTOMERGE_SET`, `MERGED`, `BLOCKED`, `PAUSED`, `ERRORED`) matches the Output bullets and the bold guard verbatim.
- **No regressions**: no removed or rewritten content; purely additive.
- **No step-10 references**: verified the added text contains no references to a non-existent step 10.
- **Conventions**: dispatch-template prose style preserved (bulleted, em-dashes, backticked tokens). 8 lines, within the 6–10 line target the issue specified.

The orchestrator's Phase 5 monitoring will dispatch a separate review subagent to fill the gap.

Closes #20