### PR TITLE
docs(work-issues): add notification-relay policy to progress reporting

### DIFF
--- a/plugins/work-issues/skills/work-issues/SKILL.md
+++ b/plugins/work-issues/skills/work-issues/SKILL.md
@@ -376,6 +376,32 @@ Example tick output:
 #340 — implementing
 ```
 
+#### Notification-relay policy
+
+Phase 5b's shell monitor and progress-tick output produce a steady drip of events during the wait-for-CI / wait-for-merge tail. Most are heartbeats — they confirm "still going" but don't carry information the user needs to act on. The TaskList badge's `in_progress` rendering already conveys "this is still going"; relaying a chat line for every heartbeat is redundant noise on top of it. **TaskList rendering is the user-facing surface for in-progress state — silence is the default during heartbeat events.** Only emit a chat-visible line for state transitions.
+
+Apply this filter before relaying any event to the user:
+
+**Always relay** — these are state transitions worth surfacing as a chat line (and a digest tick):
+
+- PR opened (URL first appears in the digest — agent transitioned out of `implementing`).
+- Code-review subagent finished (review state moves from `pending` to `done`).
+- Implementing-agent terminal returns: `AUTOMERGE_SET`, `MERGED`, `BLOCKED`, `PAUSED`, `ERRORED`.
+- Phase 5b shell-monitor events: `MERGED`, `CONFLICT`, `CI_FAILURE`, `NEW_COMMENT`.
+- Phase 5b mini-agent terminal returns: `RESOLVED` (conflict-resolution), `FIXED` (CI-failure-fix), `ADDRESSED` (review-comment), `ENVIRONMENTAL` (CI-failure-fix flake/infra).
+- A new check `conclusion == "FAILURE"` newly observed in the rollup (the digest's `CI: red` count goes up).
+- A new merge conflict newly observed (`mergeStateStatus == "DIRTY"` newly seen — the digest's `merge: conflict` first appears).
+- Merge bot didn't fire after CI went green (the tier 2 / tier 3 escalation under "Tiered remediation when AUTOMERGE_SET stalls" — the user needs to see that the orchestrator is escalating).
+
+**Suppress** — these are heartbeats; the TaskList badge is already conveying them and a chat line would be doubly redundant:
+
+- Repeated `BEHIND_RESOLVED` events from Phase 5b's shell monitor beyond the first occurrence in a given monitor session (the auto-resolve is working as designed; one notification establishes that, the rest are noise).
+- The harness's spurious post-termination "agent completed" notifications after a dispatched agent has already returned its terminal token (per the duplicate-notification note — the agent is already done, the second fire is harness-level noise).
+- Progress-tick lines whose state hasn't changed since the prior tick (every digest field — review / CI / merge — produces the same string as last tick). Skip the chat-visible emission; the next tick that surfaces a real change re-emits the full digest.
+- Per-check-pass heartbeats from any agent or monitor ("`unit` passed, 2 more pending", "More checks passing"). The aggregate `CI: pending (<done>/<total>)` field already renders progress in the digest; per-check chatter doesn't add information.
+
+When in doubt, suppress. The user can always `gh pr view <pr#>` if they want raw detail; the orchestrator's job is to surface transitions, not narrate the wait.
+
 ### Dispatch prompt template (embedded in every Agent call)
 
 The orchestrator constructs the per-agent prompt by filling in the placeholders below. The full text — not a reference — goes into the Agent call so the dispatched agent has everything it needs without consulting this skill.


### PR DESCRIPTION
## Summary
- Adds a `#### Notification-relay policy` sub-section to Phase 5's progress-reporting block. Distinguishes always-relay state transitions (PR-opened, review-finished, AUTOMERGE_SET, terminal returns, new failures, conflicts, mini-agent returns, bot-didn't-fire) from suppressible heartbeats (repeat BEHIND_RESOLVED, spurious post-termination notifications, unchanged tick state, per-check-pass heartbeats).
- Explicitly states that TaskList rendering replaces per-heartbeat user-facing text; silence is the default during heartbeat events.

Adapted from issue framing's "implementing agent's monitor loop" to current Phase 5b shell-monitor + mini-agent flow (issue #3 removed the warm monitor loop).

## Test plan
- [ ] Sub-section is in `### Progress reporting`.
- [ ] Both always-relay and suppress lists present.
- [ ] Vocabulary uses AUTOMERGE_SET, BEHIND_RESOLVED, mini-agent return tokens.
- [ ] TaskList-replaces-heartbeats statement is explicit.

### Self-review only
The `Task` / `general-purpose` subagent type is unavailable in this dispatch's harness, so a code-review subagent could not be spawned. Self-reviewed the diff against the standard checklist:

- **Scope creep:** none — only the new `#### Notification-relay policy` sub-section is added; no other content changed.
- **Placement:** sub-section sits inside `### Progress reporting` (after the example tick block, before `### Dispatch prompt template`), as the issue specifies.
- **Vocabulary:** uses current skill state — `AUTOMERGE_SET`, `BEHIND_RESOLVED`, `RESOLVED` / `FIXED` / `ADDRESSED` / `ENVIRONMENTAL` mini-agent tokens, Phase 5b shell-monitor event names (`MERGED`, `CONFLICT`, `CI_FAILURE`, `NEW_COMMENT`).
- **Cross-reference accuracy:** the bot-didn't-fire bullet references "Tiered remediation when AUTOMERGE_SET stalls", which matches the existing `### Tiered remediation when AUTOMERGE_SET stalls` heading.
- **TaskList statement:** bolded sentence makes silence-as-default explicit, satisfying the issue's acceptance criterion.
- **Conventions:** conventional commit (`docs(work-issues):`), heading hierarchy (`####` under `###`), markdown style matches surrounding sections.
- **No regressions:** doesn't touch the recently-merged sizing rule (PR #39), tiered remediation (PR #40), or CodeQL stale-aggregator content (PR #41).

Orchestrator's Phase 5 monitoring should grep for this `### Self-review only` section and dispatch its own review subagent before the merge lands.

Closes #22