### PR TITLE
feat(workflow): rename plugin to workflow, skill to implement

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,9 +14,9 @@
       "source": "./plugins/things"
     },
     {
-      "name": "work-issues",
-      "description": "Process one or more GitHub issues end-to-end through implementation and merge",
-      "source": "./plugins/work-issues"
+      "name": "workflow",
+      "description": "Workflow-automation skills (end-to-end GitHub issue execution; sibling skills planned)",
+      "source": "./plugins/workflow"
     }
   ]
 }

--- a/plugins/work-issues/.claude-plugin/plugin.json
+++ b/plugins/work-issues/.claude-plugin/plugin.json
@@ -1,7 +1,0 @@
-{
-  "name": "work-issues",
-  "description": "Process one or more GitHub issues end-to-end through implementation and merge — worktree, plan, PR, self-review, code-review subagent, CI babysitting, automerge.",
-  "author": {
-    "name": "Aidan Nagorcka-Smith"
-  }
-}

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "workflow",
+  "description": "Workflow-automation skills for end-to-end GitHub issue execution.",
+  "author": {
+    "name": "Aidan Nagorcka-Smith"
+  }
+}

--- a/plugins/workflow/skills/implement/SKILL.md
+++ b/plugins/workflow/skills/implement/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: work-issues
-description: Process one or more GitHub issues end-to-end through implementation and merge. Triggered by /work-issues with optional args (issue numbers, --label, --milestone, --parent). Self-contained orchestration — embeds the full work pipeline (worktree, plan, PR, self-review, code-review subagent, CI babysitting, automerge) so it works without project-specific CLAUDE.md scaffolding. Defaults: 3 concurrent agents, park-and-continue on blockers, sequential dependency-aware execution.
+name: implement
+description: Process one or more GitHub issues end-to-end through implementation and merge. Triggered by /workflow:implement with optional args (issue numbers, --label, --milestone, --parent). Self-contained orchestration — embeds the full work pipeline (worktree, plan, PR, self-review, code-review subagent, CI babysitting, automerge) so it works without project-specific CLAUDE.md scaffolding. Defaults: 3 concurrent agents, park-and-continue on blockers, sequential dependency-aware execution.
 ---
 
-# work-issues
+# implement
 
 Take one or more GitHub issues from intake to merge in a self-managing loop. Invoke when stepping away while several issues land.
 
@@ -11,17 +11,17 @@ The skill is self-contained: every dispatched agent receives the full work pipel
 
 ## Invocation
 
-`/work-issues [<args>]`
+`/workflow:implement [<args>]`
 
 | Form | Behaviour |
 |---|---|
-| `/work-issues 280 281 282` | Process the listed issues. |
-| `/work-issues --label <name>` | Process all open issues carrying the label. |
-| `/work-issues --milestone "<title>"` | Process all open issues in the milestone. |
-| `/work-issues --parent <n>` | Process all sub-issues of the parent issue. |
-| `/work-issues` | Default: equivalent to `--label scheduled`. |
+| `/workflow:implement 280 281 282` | Process the listed issues. |
+| `/workflow:implement --label <name>` | Process all open issues carrying the label. |
+| `/workflow:implement --milestone "<title>"` | Process all open issues in the milestone. |
+| `/workflow:implement --parent <n>` | Process all sub-issues of the parent issue. |
+| `/workflow:implement` | Default: equivalent to `--label scheduled`. |
 
-Selectors compose: `/work-issues --milestone "MS-2 General" --label scheduled` intersects them.
+Selectors compose: `/workflow:implement --milestone "MS-2 General" --label scheduled` intersects them.
 
 ## Operating principles
 
@@ -967,7 +967,7 @@ When the orchestrator observes a `MERGED` event — either from an implementing 
 When an agent reports `BLOCKED`:
 
 - Verify the `blocked` label is set on the issue and the issue has a `Claude: Blocked` comment.
-- Record the question in a parked-questions list (in-memory; optionally write to `.claude/work-issues-state.json` for resumability).
+- Record the question in a parked-questions list (in-memory; optionally write to `.claude/workflow-implement-state.json` for resumability).
 - Continue with other ready issues.
 
 When the loop drains (no more eligible issues, in-flight count = 0):
@@ -985,7 +985,7 @@ Final report to user:
 - N issues processed: X merged, Y parked, Z excluded.
 - Links to merged PRs.
 - Outstanding parked questions (if any) — `blocked` label remains, awaiting attention.
-- Suggested next step: `/work-issues --label blocked` to resume parked issues after answering.
+- Suggested next step: `/workflow:implement --label blocked` to resume parked issues after answering.
 
 ## Bail-outs (stop the entire run)
 
@@ -1005,7 +1005,7 @@ In each case: leave labels as-is, surface immediately to user, do not proceed.
 
 ## State persistence
 
-For runs that may span context windows, persist minimal state at `.claude/work-issues-state.json` in the project root:
+For runs that may span context windows, persist minimal state at `.claude/workflow-implement-state.json` in the project root:
 
 ```json
 {


### PR DESCRIPTION
## Summary
- Renames `plugins/work-issues/` to `plugins/workflow/` and the nested skill `work-issues` to `implement`. Invocation goes from `/work-issues:work-issues` to `/workflow:implement`.
- Updates `plugin.json` `name`, `marketplace.json` entry (`name` + `source` + plugin-scoped description), and SKILL.md frontmatter + internal references (slash-command examples, state-file path).
- Description rephrased to be plugin-scoped (anticipating sibling skills like `/workflow:plan`, `/workflow:review`).

## Migration note
Anyone with the marketplace plugin installed will need to refresh — `/work-issues:work-issues` no longer resolves after this lands. Reinstall as `/plugin install workflow@claude-skills`, then invoke as `/workflow:implement`.

## Out of scope (cross-repo)
The original issue's test-plan item 7 (update `agent-auth` `CLAUDE.md` to reference `/workflow:implement`) belongs on the agent-auth side and is not part of this PR.

## Notes on git rename detection
`SKILL.md` shows as a rename (98% similarity). `plugin.json` shows as delete + create because the file is only 7 lines and most lines (`name`, `description`) changed, falling below git's default similarity threshold. The underlying commit was made with `git mv`, so the object history is preserved; pass `-M10%` to `git diff` to see it as a rename.

## Test plan
- [ ] After merge, install with `/plugin install workflow@claude-skills` in a fresh Claude Code session and confirm `/workflow:implement` appears in the available-skills list.
- [ ] Confirm the old `/work-issues:work-issues` no longer resolves.
- [ ] Verify (in a separate cross-repo PR) that callers like `agent-auth/CLAUDE.md` get updated to the new invocation.

Closes #7