### PR TITLE
feat(workflow): add triage-ci-failure.sh for focused CI log slicing

### DIFF
--- a/plugins/workflow/skills/implement/SKILL.md
+++ b/plugins/workflow/skills/implement/SKILL.md
@@ -73,7 +73,7 @@ If a label doesn't exist in the repo, create it once via `gh label create` (see 
 
 ### CI discipline
 
-- Read failure logs before acting (`gh run view <run-id> --log-failed`).
+- Read failure logs before acting (`bash "$CLAUDE_PLUGIN_ROOT/skills/implement/scripts/triage-ci-failure.sh" <repo> <run-id>` — emits a focused ~30-line summary; see Phase 5 § 6.3).
 - Fix the root cause; don't pin around it, disable the check, or retry blindly.
 - Environmental / flaky failures (infra outage, rate limit, unrelated to this PR's diff) get reported but not retried — surface the issue rather than re-running.
 
@@ -586,7 +586,11 @@ Fetch PR status:
 
 For each entry with `conclusion == "FAILURE"`:
 
-1. Get logs: `gh run view <databaseId> --log-failed`.
+1. Get a focused failure summary:
+
+       bash "$CLAUDE_PLUGIN_ROOT/skills/implement/scripts/triage-ci-failure.sh" <owner/repo> <databaseId>
+
+   The script emits ~30 lines: the failing step's name, up to 10 deduplicated error-marker lines (`error:|::error::|^FAILED|Traceback|assertion|FAIL\b`, case-insensitive), and the last 10 lines of the failing step's output. This replaces piping `gh run view <databaseId> --log-failed` through ad-hoc `tail`/`head`/grep — the actual error is guaranteed to be in scope and ~3-5K tokens of unrelated log noise are skipped per investigation. If the output is empty (green-but-failed run, log unattached, API quirk), fall back to `gh run view <databaseId>` without `--log-failed` for the high-level summary.
 2. Diagnose root cause. Do NOT bypass the check.
 3. Fix; commit with a conventional-commit message referencing the failing check.
 4. `git pull --rebase` + `git push`.
@@ -968,7 +972,7 @@ The `gh api repos/.../code-scanning/alerts` endpoint requires `security_events` 
 
 #### CI-failure sizing rule
 
-On a `CI_FAILURE` event during the wait-for-merge tail, investigate before dispatching: `gh run view <run-id> --log-failed`, find root cause, don't bypass. Then size the fix:
+On a `CI_FAILURE` event during the wait-for-merge tail, investigate before dispatching: `bash "$CLAUDE_PLUGIN_ROOT/skills/implement/scripts/triage-ci-failure.sh" <repo> <run-id>` (focused ~30-line summary — see Phase 5 § 6.3 for the contract), find root cause, don't bypass. Then size the fix:
 
 - **≤50-line fix in 1-2 files** (typecheck error, lint violation, missing import, sub-block in same file): **fix in place at the orchestrator level.** Do not pay the mini-agent cold-load. Use the existing branch — the implementing agent's worktree may still exist on disk at `.claude/worktrees/agent-<id>` and is reusable; otherwise check out the branch into a fresh worktree. Commit, push, let CI re-fire. The implementing agent is gone but the branch and PR are still yours.
 - **Larger fix, multi-file refactor, or new test surface required**: dispatch the CI-failure-fix mini-agent (template below). Pays a cold-load but safer for non-trivial changes.
@@ -1051,7 +1055,11 @@ If the failing check matches one of these, follow the documented workaround inst
 
 Pipeline:
 
-1. Read the failure logs: `gh run view <run-id> --log-failed`.
+1. Read a focused failure summary:
+
+       bash "$CLAUDE_PLUGIN_ROOT/skills/implement/scripts/triage-ci-failure.sh" <repo> <run-id>
+
+   The script emits ~30 lines: failing step name, deduplicated error markers (top 10), and the last 10 lines of the failing step. This replaces the prior `gh run view <run-id> --log-failed` slicing — the actual error is guaranteed to be in scope and ~3-5K tokens of unrelated log noise are skipped. Empty output is a signal in itself (log unattached / green-but-failed run / API quirk) — fall back to `gh run view <run-id>` without `--log-failed` for the high-level summary, or treat the failure as `ENVIRONMENTAL` if the run-level metadata also looks degenerate.
 2. Diagnose the root cause. Do NOT bypass the check, disable it, or retry blindly.
 3. **A check passing 'success' isn't the same as the check doing its job.** If the failing check depends on an upstream artifact (e.g. `changelog-lint` failing because no `pr-<N>-*.yml` exists), look at the upstream workflow's logs for `secrets not configured`-style notices before concluding it's a real failure.
 4. Fix the root cause. Commit with a conventional-commits message referencing the failing check (e.g. `fix(ci): correct lint config for <check>`).

--- a/plugins/workflow/skills/implement/scripts/triage-ci-failure.sh
+++ b/plugins/workflow/skills/implement/scripts/triage-ci-failure.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Emit a focused 20-40 line summary of a failed CI run for the workflow:implement
+# skill's CI-failure recovery paths (Phase 5b CI-failure-fix mini-agent and the
+# dispatch prompt's § 6.3 "Address CI failures").
+#
+# Replaces the prior practice of running `gh run view <run-id> --log-failed`
+# directly and slicing the raw log by hand. GitHub Actions logs interleave every
+# step's output plus environment dumps and setup spam; ad-hoc `tail`/`head`/grep
+# slicing either misses the actual error or buries it in noise. Per-failure
+# investigation cost was ~3-5K tokens of unrelated log content; this script
+# narrows that to ~30 lines with the actual error guaranteed to be in scope.
+#
+# Output shape (stdout):
+#   === failing step: <name> ===
+#
+#   === error markers ===
+#   <up to 10 deduplicated lines matching error/FAIL/Traceback/assertion/::error::>
+#
+#   === final 10 lines ===
+#   <last 10 lines of the failing step's log>
+#
+# Defensive against gh/API quirks: any sub-call that fails (run not found,
+# no failing step recorded, log unattached on a green-but-failed run) yields
+# an empty section rather than an error exit. Empty output is acceptable —
+# the calling agent should recognise it and fall back to `gh run view <run-id>`
+# without `--log-failed`, or treat the failure as ENVIRONMENTAL.
+#
+# Usage: triage-ci-failure.sh <owner/repo> <run-id>
+
+set -euo pipefail
+
+repo="${1:?repo required, e.g. aidanns/claude-skills}"
+run_id="${2:?run id required}"
+
+# --- Failing step name ------------------------------------------------------
+#
+# `gh run view --json jobs` returns every job and its steps with conclusions.
+# Pick the first step whose conclusion is "failure" — this is what `--log-failed`
+# is keyed on, so the slicing below stays consistent with what the agent sees.
+# Fall back to "(unknown)" if no failing step is recorded (green-but-failed
+# runs, API quirks, races where the run is still finalising).
+step=$(gh run view "$run_id" --repo "$repo" --json jobs \
+  --jq '[.jobs[]? | .steps[]? | select(.conclusion == "failure")] | first | .name // "(unknown)"' \
+  2>/dev/null || echo "(unknown)")
+
+printf '=== failing step: %s ===\n\n' "$step"
+
+# --- Failure log ------------------------------------------------------------
+#
+# `--log-failed` returns only the failing job/step output (still verbose, but
+# scoped). Suppress errors so a missing-log run still produces a sensible stub.
+log=$(gh run view "$run_id" --repo "$repo" --log-failed 2>/dev/null || true)
+
+# --- Error markers ----------------------------------------------------------
+#
+# Case-insensitive grep for lines that announce errors, test failures,
+# tracebacks, or assertion failures. Dedupe with `sort -u` so a repeated stack
+# trace doesn't crowd out other signals, then cap at 10 to keep total output
+# in the 20-40 line target.
+#
+# `FAIL\b` requires a word boundary so we don't match "FAILED" inside benign
+# step names ("Run failed-test-detector", etc.) — only the literal marker.
+echo "=== error markers ==="
+if [[ -n "$log" ]]; then
+  grep -iE 'error:|::error::|^FAILED|Traceback|assertion|FAIL\b' <<<"$log" \
+    | sort -u | head -10 || true
+fi
+echo
+
+# --- Final 10 lines of the failing step -------------------------------------
+#
+# The last 10 lines of `--log-failed` are usually the actual failure point
+# (test runner summary, compiler error, exit-code report). Keeping this even
+# when error-marker grep returns hits gives the agent the trailing context
+# without a second log fetch.
+echo "=== final 10 lines ==="
+if [[ -n "$log" ]]; then
+  tail -10 <<<"$log"
+fi


### PR DESCRIPTION
## Summary

- New `plugins/workflow/skills/implement/scripts/triage-ci-failure.sh <repo> <run-id>` emits a focused ~30-line summary of a failed CI run: failing-step name, deduplicated top-10 error-marker lines (matching `error:|::error::|^FAILED|Traceback|assertion|FAIL\b` case-insensitively), and the last 10 lines of the failing step.
- Replaces the prior `gh run view <run-id> --log-failed` + ad-hoc `tail`/`head`/grep slicing in four call-sites in the workflow:implement skill: Phase 5 § 6.3 (dispatch prompt), Phase 5b CI-failure-fix mini-agent, Phase 5b orchestrator-level CI-failure sizing rule, and the CI-discipline operating-principles bullet.
- Defensive against gh API quirks (run not found / log unattached / green-but-failed run): each sub-call traps errors so empty sections render gracefully rather than crashing — empty output is itself a signal that the calling agent can recognise and fall back from.
- Saves ~3-5K tokens per failure investigation; keeps the actual error in scope and skips environment dumps / setup spam from interleaved log output.

### Self-review only

The implementing harness lacked a `general-purpose` `Task` / `Agent` subagent type, so this PR was prepared with a self-review pass against the simplify checklist (reuse / quality / efficiency) instead of an independent code-review subagent. One narrative comment ("the regex from issue #54") was removed in self-review; otherwise no changes. Reviewer at merge-time: please apply the standard review subagent pass.

## Test plan

- [x] `bash -n` and `shellcheck` are clean on the new script.
- [x] Running the script with a non-existent run-id exits 0 with the empty-section stub output.
- [x] Running the script against a real failed CI run produces a focused summary in which the actual error message is visible (verified locally against `aidanns/agent-auth` run 24991269204 — surfaced "Repository rule violations found" / "12 of 12 required status checks are expected" in <20 lines).
- [x] All four call-sites in `SKILL.md` invoke the script via `$CLAUDE_PLUGIN_ROOT/skills/implement/scripts/triage-ci-failure.sh`, matching the pattern established by `phase15-conventions.sh` and `digest-line.sh`.

Closes #54