### PR TITLE
docs(workflow): align implement description with post-#75 split

### DIFF
--- a/plugins/workflow/skills/implement/SKILL.md
+++ b/plugins/workflow/skills/implement/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implement
-description: Process one or more GitHub issues end-to-end through implementation and merge. Triggered by /workflow:implement with optional args (issue numbers, --label, --milestone, --parent). Self-contained orchestration — embeds the full work pipeline (worktree, plan, PR, self-review, code-review subagent, CI babysitting, automerge) so it works without project-specific CLAUDE.md scaffolding. Defaults: 3 concurrent agents, park-and-continue on blockers, sequential dependency-aware execution.
+description: Process one or more GitHub issues end-to-end. Triggered by /workflow:implement with optional args (issue numbers, --label, --milestone, --parent). The implementing agent runs in an isolated worktree (worktree → plan → PR → self-review → `READY_FOR_REVIEW`); the orchestrator owns review, address-review, CI fix-up, automerge handoff, and post-merge monitoring. Self-contained — embeds the full pipeline in dispatched-agent prompts so it works without project-specific CLAUDE.md scaffolding. Defaults: 3 concurrent implementing agents, park-and-continue on blockers, sequential dependency-aware execution.
 ---
 
 # implement


### PR DESCRIPTION
## Summary
- Rewrite the `implement` skill's frontmatter description so it reflects the post-#75 / post-#76 split: the implementing agent's pipeline ends at `READY_FOR_REVIEW`, while the orchestrator owns review, address-review, CI fix-up, automerge handoff, and post-merge monitoring.
- Name the `READY_FOR_REVIEW` terminal token in the description so the contract is discoverable from the skill listing alone.
- Preserve the trigger / args sentence and the Defaults sentence verbatim in spirit (Defaults clarified to "implementing agents").

## Test plan
- [ ] `git diff main...HEAD` shows only the frontmatter `description:` line changed in `plugins/workflow/skills/implement/SKILL.md`.
- [ ] New description no longer mentions code-review subagent, CI babysitting, or automerge as work the implementing agent does.
- [ ] New description includes the literal token `READY_FOR_REVIEW`.
- [ ] Trigger sentence (`/workflow:implement` + args) and Defaults sentence are still present.

Closes #78