### PR TITLE
fix(workflow): drop redundant issue_count gate on LGTM digest

### DIFF
--- a/plugins/workflow/skills/implement/SKILL.md
+++ b/plugins/workflow/skills/implement/SKILL.md
@@ -587,7 +587,7 @@ The script's exit code is always `0`; the orchestrator distinguishes outcomes vi
 
    - Both 0 → `review: pending`.
    - Inline count ≥ 1 → `review: done (<n> findings)`.
-   - Inline 0 and exactly one issue-level comment matching `Claude Reviewer: LGTM` → `review: done (LGTM)`.
+   - Inline 0 and exactly one `Claude Reviewer: LGTM` issue-level comment, regardless of how many other PR-level comments exist (the implementing agent posts its own `Claude: ` notes — e.g. environmental-CI retries — and gating on the total PR-level count would suppress this branch whenever such a note exists) → `review: done (LGTM)`.
 
 3. **CI state** — aggregate `statusCheckRollup` from the `gh pr list` query above:
 

--- a/plugins/workflow/skills/implement/scripts/digest-line.sh
+++ b/plugins/workflow/skills/implement/scripts/digest-line.sh
@@ -58,13 +58,22 @@ esac
 # --- Review status ---------------------------------------------------------
 #
 # Count `Claude Reviewer:` comments — inline (per-line review comments) and
-# issue-level (PR-level comments). The review subagent posts either inline
-# findings or a single `Claude Reviewer: LGTM` PR-level comment; the
-# implementing agent uses `Claude:`, so the prefix discriminates.
+# the LGTM PR-level comment. The review subagent posts either inline findings
+# or a single `Claude Reviewer: LGTM` PR-level comment; the implementing
+# agent uses `Claude:`, so the prefix discriminates.
+#
+# We do *not* gate the LGTM branch on a total-PR-level-comment count: the
+# implementing agent legitimately posts its own `Claude:` PR-level comments
+# (e.g. "CI failure was environmental, retrying" per the dispatch template's
+# 6.3 rules), and a stricter "exactly one PR-level comment overall" check
+# would suppress `done (LGTM)` whenever any such note exists. The `lgtm_count`
+# query already filters by the `Claude Reviewer: LGTM` prefix, which is
+# sufficient on its own.
+#
+# Test case: implementing agent posts one `Claude: ...` PR-level comment AND
+# the review subagent posts `Claude Reviewer: LGTM. <summary>`. Then
+# inline_count == 0, lgtm_count == 1, and the digest emits `done (LGTM)`.
 inline_count=$(gh api "repos/${repo}/pulls/${pr_number}/comments" \
-  --jq '[.[] | select(.body | startswith("Claude Reviewer: "))] | length' \
-  2>/dev/null || echo 0)
-issue_count=$(gh api "repos/${repo}/issues/${pr_number}/comments" \
   --jq '[.[] | select(.body | startswith("Claude Reviewer: "))] | length' \
   2>/dev/null || echo 0)
 lgtm_count=$(gh api "repos/${repo}/issues/${pr_number}/comments" \
@@ -73,7 +82,7 @@ lgtm_count=$(gh api "repos/${repo}/issues/${pr_number}/comments" \
 
 if (( inline_count >= 1 )); then
   review_state="done (${inline_count} findings)"
-elif (( inline_count == 0 )) && (( lgtm_count == 1 )) && (( issue_count == 1 )); then
+elif (( inline_count == 0 )) && (( lgtm_count == 1 )); then
   review_state="done (LGTM)"
 else
   review_state="pending"


### PR DESCRIPTION
## Summary

- `digest-line.sh`'s `done (LGTM)` branch was gated on `issue_count == 1` in addition to `lgtm_count == 1`. The implementing agent legitimately posts its own `Claude: ...` PR-level comments (e.g. environmental-CI retries per the dispatch template's 6.3 rules), so any such note would push the count past 1 and the digest would stall on `review: pending` even after the review subagent's clean LGTM landed.
- The `lgtm_count` query already filters by the `Claude Reviewer: LGTM` prefix, which is sufficient on its own — drop the redundant clause and remove the now-unused `issue_count` computation.
- Update Phase 5 § Progress reporting in `SKILL.md` so the prose describes "exactly one `Claude Reviewer: LGTM` issue-level comment, regardless of other PR-level comments" and stays aligned with the script.

## Test plan

- [ ] `bash -n plugins/workflow/skills/implement/scripts/digest-line.sh`
- [ ] `shellcheck plugins/workflow/skills/implement/scripts/digest-line.sh`
- [ ] Walk through the bug scenario from the issue: implementing agent posts one `Claude: ...` PR-level comment AND the reviewer posts `Claude Reviewer: LGTM. <summary>` → digest emits `review: done (LGTM)` (was `review: pending`).
- [ ] Confirm the `inline_count >= 1` branch is unaffected (still emits `done (<n> findings)`).
- [ ] Confirm the fall-through `pending` branch is unaffected (no comments at all → still `pending`).

Closes #79