### PR TITLE
fix(workflow): detect label-triggered merge-bot pattern

### DIFF
--- a/plugins/workflow/skills/implement/scripts/phase15-conventions.sh
+++ b/plugins/workflow/skills/implement/scripts/phase15-conventions.sh
@@ -10,6 +10,62 @@
 
 set -euo pipefail
 
+# --- Pure-text workflow predicates ------------------------------------------
+#
+# These two helpers are separated from the network-touching main flow so the
+# regression test (`tests/test-phase15-conventions.sh`) can exercise them
+# directly against fixture files. Keep them stdin-driven so the test can pipe
+# in a fixture without a tempfile dance.
+
+# Does this workflow listen for `pull_request: types: [..., labeled, ...]`?
+#
+# Handles both YAML list shapes that GitHub Actions accepts:
+#   - inline flow:  types: [labeled]   /   types: [opened, labeled]
+#   - block list:   types:
+#                     - labeled
+#
+# The previous heuristic only recognised the block form because it anchored
+# on a leading `-` at line start. `merge-bot.yml`-shaped workflows that use
+# the inline flow form (`types: [labeled]`) silently fell through and were
+# excluded from the merge-mechanism candidate set, even though they were the
+# very files that should have triggered the label-bot branch.
+phase15_workflow_listens_to_labeled() {
+  local content="$1"
+  # Inline flow list: `types: [..., labeled, ...]`. The character class lets
+  # us match across whitespace inside the brackets without having to handle
+  # multi-line flow lists (GitHub Actions workflows in the wild keep the
+  # flow form on a single line).
+  if grep -qE 'types:[[:space:]]*\[[^]]*\blabeled\b[^]]*\]' <<<"$content"; then
+    return 0
+  fi
+  # Block list: a `- labeled` entry on its own line.
+  if grep -qE '^[[:space:]]*-[[:space:]]+labeled[[:space:]]*$' <<<"$content"; then
+    return 0
+  fi
+  return 1
+}
+
+# Extract the first label name guarded by an `if:` in this workflow.
+#
+# Recognises the two shapes the merge-bot patterns use:
+#   if: github.event.label.name == 'automerge'
+#   if: contains(github.event.pull_request.labels.*.name, 'automerge')
+#
+# Both shapes work when buried inside a multi-line `if:` block joined by
+# `||` clauses (e.g. `merge-bot.yml`'s primary trigger gate) — the regex
+# is whitespace-tolerant and content-anchored, not line-anchored.
+phase15_extract_label_guard() {
+  local content="$1"
+  grep -oE "(label\.name[[:space:]]*==[[:space:]]*'[^']+'|labels\.\\*\\.name,[[:space:]]*'[^']+')" \
+    <<<"$content" | grep -oE "'[^']+'" | head -1 | tr -d "'" || true
+}
+
+# When sourced (e.g. by the regression test), expose only the helpers. Skip
+# argument parsing and all `gh api` calls so the test runs offline.
+if [[ "${BASH_SOURCE[0]:-$0}" != "$0" ]]; then
+  return 0
+fi
+
 repo="${1:?repo required, e.g. aidanns/claude-skills}"
 
 # --- Sample: most recent merged PRs -----------------------------------------
@@ -178,17 +234,9 @@ if [[ -n "$workflows" ]]; then
       --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)
     [[ -z "$wf_content" ]] && continue
 
-    # Listens to `pull_request: types: [..., labeled, ...]`?
-    if ! grep -qE '^[[:space:]]*-?[[:space:]]*labeled([[:space:]]|$|,)' \
-        <<<"$wf_content"; then
-      continue
-    fi
+    phase15_workflow_listens_to_labeled "$wf_content" || continue
 
-    # Extract a label name from the workflow's `if:` guard. Common shapes:
-    #   if: github.event.label.name == 'automerge'
-    #   if: contains(github.event.pull_request.labels.*.name, 'automerge')
-    label=$(grep -oE "(label\.name[[:space:]]*==[[:space:]]*'[^']+'|labels\.\\*\\.name,[[:space:]]*'[^']+')" \
-      <<<"$wf_content" | grep -oE "'[^']+'" | head -1 | tr -d "'" || true)
+    label=$(phase15_extract_label_guard "$wf_content")
     if [[ -n "$label" ]]; then
       candidate_label="$label"
       break

--- a/plugins/workflow/skills/implement/scripts/tests/fixtures/labeled-no-guard.yml
+++ b/plugins/workflow/skills/implement/scripts/tests/fixtures/labeled-no-guard.yml
@@ -1,0 +1,19 @@
+# Negative fixture: the workflow listens for `labeled` events but its if
+# expression accepts every label change indiscriminately. The detector must
+# NOT extract a candidate label here, otherwise it would mis-emit the
+# label-bot trailer for a repo that doesn't actually use a label-triggered
+# merge bot. (The comment intentionally avoids quoting the guard syntax so
+# the regex doesn't match prose.)
+
+name: Label Audit
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - run: echo "audit any label change"

--- a/plugins/workflow/skills/implement/scripts/tests/fixtures/merge-bot-block-list.yml
+++ b/plugins/workflow/skills/implement/scripts/tests/fixtures/merge-bot-block-list.yml
@@ -1,0 +1,19 @@
+# Companion fixture: same merge-bot pattern but with the `types:` value
+# written as a YAML block list (one entry per line, leading `-`). Both list
+# styles are valid GitHub Actions syntax, so both must be detected.
+
+name: Merge Bot (block-list variant)
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - synchronize
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'automerge')
+    steps:
+      - run: echo "merge"

--- a/plugins/workflow/skills/implement/scripts/tests/fixtures/merge-bot-inline-flow.yml
+++ b/plugins/workflow/skills/implement/scripts/tests/fixtures/merge-bot-inline-flow.yml
@@ -1,0 +1,31 @@
+# Regression fixture for issue #101.
+#
+# Captures the exact shapes that broke the original Phase 1.5 detector on
+# `aidanns/agent-auth/.github/workflows/merge-bot.yml`:
+#   1. `pull_request: types: [labeled]` written as an inline-flow YAML list
+#      (single line, square brackets) rather than a block list.
+#   2. The `automerge` label-name guard buried inside a multi-line `if:`
+#      block joined by `||` clauses, so it isn't on the same line as the
+#      `if:` keyword.
+# Both shapes must be detected for the merge-mechanism trailer to flip from
+# the default `gh pr merge --auto --squash` to the label-bot branch.
+
+name: Merge Bot
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_run:
+    workflows: [Test, Check]
+    types: [completed]
+  workflow_dispatch:
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'pull_request' && github.event.action == 'labeled' && github.event.label.name == 'automerge')
+      || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+      || github.event_name == 'workflow_dispatch'
+    steps:
+      - run: echo "merge"

--- a/plugins/workflow/skills/implement/scripts/tests/fixtures/no-pull-request-trigger.yml
+++ b/plugins/workflow/skills/implement/scripts/tests/fixtures/no-pull-request-trigger.yml
@@ -1,0 +1,14 @@
+# Negative fixture: workflow does not subscribe to `pull_request: labeled`
+# at all. The detector must reject it before label-guard extraction.
+
+name: Nightly
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "nightly"

--- a/plugins/workflow/skills/implement/scripts/tests/test-phase15-conventions.sh
+++ b/plugins/workflow/skills/implement/scripts/tests/test-phase15-conventions.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# Regression tests for the Phase 1.5 merge-mechanism detector in
+# `phase15-conventions.sh`. Sources the script (the script's main flow is
+# guarded so sourcing exposes only the pure-text helpers) and exercises the
+# workflow-listens-for-`labeled` and label-guard-extraction predicates
+# against the fixtures in `fixtures/`. No network calls.
+#
+# Run: bash plugins/workflow/skills/implement/scripts/tests/test-phase15-conventions.sh
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fixtures="${here}/fixtures"
+
+# shellcheck source=../phase15-conventions.sh
+source "${here}/../phase15-conventions.sh"
+
+failed=0
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    printf 'ok   %s\n' "$name"
+  else
+    printf 'FAIL %s\n      expected: %q\n      actual:   %q\n' \
+      "$name" "$expected" "$actual"
+    failed=1
+  fi
+}
+
+assert_listens() {
+  local name="$1" fixture="$2" expected="$3"
+  local content; content="$(cat "${fixtures}/${fixture}")"
+  if phase15_workflow_listens_to_labeled "$content"; then
+    actual=true
+  else
+    actual=false
+  fi
+  assert_eq "$name" "$expected" "$actual"
+}
+
+assert_guard() {
+  local name="$1" fixture="$2" expected="$3"
+  local content; content="$(cat "${fixtures}/${fixture}")"
+  local actual; actual="$(phase15_extract_label_guard "$content")"
+  assert_eq "$name" "$expected" "$actual"
+}
+
+# Issue #101: inline-flow `types: [labeled]` plus a multi-line `if:` block
+# whose label-name guard is buried inside an `||` clause. The pre-fix
+# detector missed both halves of this pattern and so emitted the wrong
+# `Merge mechanism:` trailer.
+assert_listens "inline-flow types: [labeled] is recognised" \
+  "merge-bot-inline-flow.yml" true
+assert_guard   "label.name guard inside multi-line if: is extracted" \
+  "merge-bot-inline-flow.yml" "automerge"
+
+# Block-list `types:` with `- labeled` plus a `labels.*.name, 'X'` guard.
+# Both shapes appear in the wild; both must be detected.
+assert_listens "block-list - labeled entry is recognised" \
+  "merge-bot-block-list.yml" true
+assert_guard   "labels.*.name contains() guard is extracted" \
+  "merge-bot-block-list.yml" "automerge"
+
+# Negative: workflow listens for `labeled` but does not gate on a specific
+# label. Must not yield a candidate label.
+assert_listens "labeled trigger without label guard is still detected as labeled" \
+  "labeled-no-guard.yml" true
+assert_guard   "no label guard yields empty extraction" \
+  "labeled-no-guard.yml" ""
+
+# Negative: workflow does not subscribe to `pull_request: labeled` at all.
+assert_listens "non-pull_request workflow is rejected" \
+  "no-pull-request-trigger.yml" false
+
+if (( failed != 0 )); then
+  printf '\nFAIL: one or more assertions failed.\n' >&2
+  exit 1
+fi
+
+printf '\nAll phase15-conventions assertions passed.\n'


### PR DESCRIPTION
## Summary

- The Phase 1.5 merge-mechanism detector (`plugins/workflow/skills/implement/scripts/phase15-conventions.sh`) skipped any workflow whose `pull_request: types:` was written as an inline-flow YAML list (e.g. `types: [labeled]`) because the listening check anchored on a leading `-` at line start. `aidanns/agent-auth/.github/workflows/merge-bot.yml` uses that form, so the detector silently fell through to the default `gh pr merge --auto --squash` trailer instead of `apply automerge label (merge-bot picks it up)`.
- Replace the line-anchored grep with `phase15_workflow_listens_to_labeled` (handles both inline-flow `types: [labeled]` and block-style `- labeled`) and factor the label-name extraction into `phase15_extract_label_guard`. Add a source-guard so the regression test can source the script and drive the helpers offline.
- Add a regression test (`tests/test-phase15-conventions.sh`) plus four fixtures covering: the inline-flow merge-bot shape (the regression), the block-list variant, a `labeled` trigger without a label-name guard, and a non-`pull_request` workflow.

## Test plan

- [ ] `bash plugins/workflow/skills/implement/scripts/tests/test-phase15-conventions.sh` exits 0 with all seven assertions passing.
- [ ] Sourcing `phase15-conventions.sh` and feeding it the live `aidanns/agent-auth/.github/workflows/merge-bot.yml` content yields `listens: yes` and `guard: automerge`.
- [ ] Direct invocation `bash plugins/workflow/skills/implement/scripts/phase15-conventions.sh` (no args) still errors out with the original `repo required` message — i.e. the main flow is unchanged.

Closes #101

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>