### PR TITLE
feat(workflow): emit MONITOR_DEGRADED on upstream failures

### DIFF
--- a/plugins/workflow/skills/implement/SKILL.md
+++ b/plugins/workflow/skills/implement/SKILL.md
@@ -755,7 +755,7 @@ Apply this filter before relaying any event to the user:
 - Orchestrator-level review subagent finished: `LGTM` (review state moves to `done (LGTM)`) or `FINDINGS <count>` (review state moves to `done (<count> findings)`).
 - Address-review fallback mini-agent terminal return (rare — only on the warm-agent-unreachable path): `READY_TO_MERGE` (orchestrator is about to set automerge).
 - Orchestrator sets automerge (the warm agent's `READY_TO_MERGE` return — or, in the fallback path, the address-review mini-agent's `READY_TO_MERGE` — fires the merge handoff per the observed `Merge mechanism:` line) — this is the "merging" state in the state machine.
-- Phase 5b shell-monitor events: `MERGED`, `CLOSED` (PR closed without merging — surface so the user notices the run won't reach all-terminal), `CONFLICT`, `CI_FAILURE`, `NEW_COMMENT`, `BEHIND_RESOLVE_FAILED` (the monitor's `git push` was rejected after a local catch-up — usually a PAT-scope issue; the PR is parked until the user intervenes), `STALLED_GREEN` (the merge bot didn't fire after CI went green; the orchestrator is running the tier 2 / 3 / 4 ladder).
+- Phase 5b shell-monitor events: `MERGED`, `CLOSED` (PR closed without merging — surface so the user notices the run won't reach all-terminal), `CONFLICT`, `CI_FAILURE`, `NEW_COMMENT`, `BEHIND_RESOLVE_FAILED` (the monitor's `git push` was rejected after a local catch-up — usually a PAT-scope issue; the PR is parked until the user intervenes), `MONITOR_DEGRADED` (an upstream step of the BEHIND auto-resolve — `clone` / `fetch` / `merge` — failed, so the auto-resolve can't proceed; the PR is parked until the upstream issue clears or the user intervenes; deduped to once-per-`<step>:<pr>` per session so persistent failures don't spam chat), `STALLED_GREEN` (the merge bot didn't fire after CI went green; the orchestrator is running the tier 2 / 3 / 4 ladder).
 - Phase 5b mini-agent terminal returns: `RESOLVED` (conflict-resolution), `FIXED` (CI-failure-fix), `ADDRESSED` (review-comment), `ENVIRONMENTAL` (CI-failure-fix flake/infra).
 - A new check `conclusion == "FAILURE"` newly observed in the rollup (the digest's `CI: red` count goes up).
 - A new merge conflict newly observed (`mergeStateStatus == "DIRTY"` newly seen — the digest's `merge: conflict` first appears).
@@ -1001,6 +1001,8 @@ The monitor is a single bash script. Stdout lines are events; the orchestrator r
 
 Save as `monitor-pr.sh` (or paste inline into the `Monitor` tool's command — both work). Invocation: `monitor-pr.sh <pr#> <pr-branch> <repo-base-branch>` (e.g. `monitor-pr.sh 451 aidanns/foo-fix main`).
 
+The BEHIND auto-resolve subroutine is factored out into `scripts/monitor-behind-resolve.sh` (colocated with this skill at `$CLAUDE_PLUGIN_ROOT/skills/implement/scripts/monitor-behind-resolve.sh`) so its upstream-step error handling is unit-testable. The outer monitor below shells out to it on each BEHIND tick.
+
 ```bash
 #!/usr/bin/env bash
 #
@@ -1020,6 +1022,14 @@ emit() { printf '%s\n' "$*"; }  # one event per line, line-buffered by default.
 # don't re-emit on every tick.
 seen_failures=""   # space-separated run IDs.
 seen_comments=""   # space-separated comment IDs.
+
+# Dedupe file for MONITOR_DEGRADED events emitted by the BEHIND auto-resolve
+# helper. The helper runs in its own process (so a bash variable wouldn't
+# survive across ticks anyway), and the BEHIND auto-resolve runs in a
+# subshell here -- a tempfile is the simplest way for the dedupe state to
+# span both boundaries. Each line in the file is a `<step>:<pr>` marker.
+degraded_dedupe=$(mktemp)
+trap 'rm -f "$degraded_dedupe"' EXIT
 
 # Track "time since the PR's observable state last changed" so we can detect
 # the steady-state "green + automerge applied + open + mergeable" stall and
@@ -1068,35 +1078,13 @@ while :; do
   fi
 
   # ---- BEHIND + MERGEABLE: auto-resolve in-shell (no LLM). ----
-  # Automerge does NOT auto-update behind branches. We catch it up locally.
+  # Automerge does NOT auto-update behind branches. We catch it up locally
+  # via the helper, which also surfaces upstream-step failures (clone /
+  # fetch / merge) as MONITOR_DEGRADED so a broken auto-resolve doesn't
+  # silently loop the BEHIND state forever.
   if [[ "$msstatus" == "BEHIND" && "$mergeable" != "CONFLICTING" ]]; then
-    (
-      tmpdir=$(mktemp -d)
-      cd "$tmpdir"
-      gh repo clone "$(gh repo view --json nameWithOwner -q .nameWithOwner)" repo -- --branch "$branch" --depth 50 >/dev/null 2>&1 || exit 0
-      cd repo
-      git fetch origin "$base" >/dev/null 2>&1 || exit 0
-      if git merge --no-edit "origin/$base" >/dev/null 2>&1; then
-        # Capture push stderr so we can surface failures (e.g. PAT missing
-        # `workflow` scope rejecting changes under `.github/workflows/*`).
-        # Only emit BEHIND_RESOLVED when the push actually landed; otherwise
-        # the next tick would observe BEHIND again and silently loop.
-        push_err=$(git push origin "$branch" 2>&1 >/dev/null)
-        push_rc=$?
-        if [[ $push_rc -eq 0 ]]; then
-          emit "BEHIND_RESOLVED $pr"
-        else
-          # Collapse newlines/tabs so the event line stays single-line.
-          reason=$(printf '%s' "$push_err" | tr '\n\t' '  ' | sed 's/  */ /g')
-          emit "BEHIND_RESOLVE_FAILED $pr $reason"
-        fi
-      else
-        # The merge produced conflicts — escalate via the CONFLICT path below
-        # on the next tick (don't double-emit here).
-        git merge --abort >/dev/null 2>&1 || true
-      fi
-      rm -rf "$tmpdir"
-    )
+    bash "$CLAUDE_PLUGIN_ROOT/skills/implement/scripts/monitor-behind-resolve.sh" \
+      "$pr" "$branch" "$base" "$degraded_dedupe"
   fi
 
   # ---- DIRTY / CONFLICTING: escalate to conflict-resolution mini-agent. ----
@@ -1181,6 +1169,7 @@ Key behaviours:
 
 - **`BEHIND` auto-resolution stays in-shell.** Uses the same local-merge approach the implementing agent uses (`git fetch origin main && git merge --no-edit origin/main && git push`) — no `update-branch` API call, consistent with the rest of this skill.
 - **Push failures are surfaced, not swallowed.** `git push` stderr is captured and the exit code is checked. On failure, the monitor emits `BEHIND_RESOLVE_FAILED <pr#> <reason>` instead of `BEHIND_RESOLVED`, so a silently-rejected push (e.g. PAT missing `workflow` scope on `.github/workflows/*` changes) escalates to the user instead of the next tick re-observing BEHIND and looping. `BEHIND_RESOLVED` is only emitted when the push actually landed.
+- **Upstream-step failures are surfaced, not swallowed.** The `gh repo clone` / `git fetch` / `git merge` steps that precede the push each capture their stderr and emit `MONITOR_DEGRADED <pr#> <step> <reason>` on failure (where `<step>` is `clone` / `fetch` / `merge`). Without this surfacing, a broken auto-resolve (e.g. `gh repo view` failing in the monitor's tmpdir, a stale clone token, an unrelated-histories merge error) was invisible to the orchestrator: BEHIND would persist for poll after poll with no event, no `BEHIND_RESOLVED`, no `BEHIND_RESOLVE_FAILED`, and the user had to diagnose by hand. Each `<step>:<pr>` combination emits at most once per monitor session (dedupe lives in the `degraded_dedupe` tempfile) so a persistent failure surfaces exactly once. `gh repo view` is folded into the `clone` step because the view call is a substitution argument to the clone — if view fails the clone fails, and capturing the clone stderr captures both. A `git merge` that produces conflicts (rather than a hard merge error) is *not* surfaced as `MONITOR_DEGRADED merge` — it falls through to the next tick's CONFLICT path so the conflict-resolution mini-agent gets dispatched, same as before.
 - **Transient `gh` failures** (network blips, rate-limit retries) don't crash the loop — `|| true` and an empty-result check keep polling.
 - **Deduplication** — failing run IDs and review comment IDs are tracked, so a persistent failure escalates exactly once per ID, not on every tick.
 - **`Claude` -prefixed comments are skipped** so the monitor doesn't re-escalate on the implementing agent's or reviewer subagent's own comments.
@@ -1198,6 +1187,7 @@ The `Monitor` tool surfaces each stdout line of `monitor-pr.sh` as a notificatio
 | `CLOSED <pr-url>` | Surface to user — PR was closed without merging. Stop the monitor. |
 | `BEHIND_RESOLVED <pr#>` | Log only. Refresh the next progress digest. |
 | `BEHIND_RESOLVE_FAILED <pr#> <reason>` | Surface to user — the monitor caught up the branch locally but the `git push` was rejected (commonly a PAT-scope issue, e.g. missing `workflow` scope when the PR touches `.github/workflows/*`). Stop the monitor; treat the PR as parked until the user resolves the auth/permission issue. Do **not** loop — the next tick would just re-observe BEHIND and fail the same way. |
+| `MONITOR_DEGRADED <pr#> <step> <reason>` | Surface to user — an upstream step (`<step>` is `clone` / `fetch` / `merge`) of the BEHIND auto-resolve failed, so the auto-resolve cannot complete. Park the PR (treat as user-attention-needed; the BEHIND state will persist until either the upstream issue clears or the user intervenes). The monitor keeps polling — the failure may self-recover (e.g. transient `gh` network blip, stale tmpdir CWD that becomes valid again next tick) and each `<step>:<pr>` is deduplicated so a persistent failure produces exactly one event per monitor session, not one per tick. Optionally `update-issue <id> <n> errored` if the step failure looks non-recoverable from the reason text (clone permission denied, repo not found, etc.). Distinct from `BEHIND_RESOLVE_FAILED`, which surfaces a *push*-specific rejection after the upstream steps succeeded. |
 | `CONFLICT <pr#> <branch> <base> <files>` | Dispatch the **conflict-resolution mini-agent** (template below). |
 | `CI_FAILURE <pr#> <check> <run-id>` | Size the fix first (see **CI-failure sizing rule** below). If ≤50 lines / 1-2 files, fix in-place at the orchestrator level. Otherwise dispatch the **CI-failure-fix mini-agent** (template below). |
 | `NEW_COMMENT <pr#> <comment-id>` | Dispatch the **review-comment mini-agent** (template below). |

--- a/plugins/workflow/skills/implement/SKILL.md
+++ b/plugins/workflow/skills/implement/SKILL.md
@@ -999,9 +999,9 @@ When step 5 of the Phase 5 execution loop sets automerge (after the warm impleme
 
 The monitor is a single bash script. Stdout lines are events; the orchestrator routes each event line to the appropriate handler. Stderr is for the script's own diagnostics (logged but not interpreted as events).
 
-Save as `monitor-pr.sh` (or paste inline into the `Monitor` tool's command — both work). Invocation: `monitor-pr.sh <pr#> <pr-branch> <repo-base-branch>` (e.g. `monitor-pr.sh 451 aidanns/foo-fix main`).
+Paste inline into the `Monitor` tool's command (the orchestrator dispatches it from a context where `$CLAUDE_PLUGIN_ROOT` is exported). Invocation form: `monitor-pr.sh <pr#> <pr-branch> <repo-base-branch>` (e.g. `monitor-pr.sh 451 aidanns/foo-fix main`). The recipe is **not** self-contained — it shells out to a colocated helper for the BEHIND auto-resolve (see next paragraph) — so saving it as a standalone `monitor-pr.sh` and running it outside the orchestrator only works if you also export `CLAUDE_PLUGIN_ROOT` to point at this plugin's checkout.
 
-The BEHIND auto-resolve subroutine is factored out into `scripts/monitor-behind-resolve.sh` (colocated with this skill at `$CLAUDE_PLUGIN_ROOT/skills/implement/scripts/monitor-behind-resolve.sh`) so its upstream-step error handling is unit-testable. The outer monitor below shells out to it on each BEHIND tick.
+The BEHIND auto-resolve subroutine is factored out into `scripts/monitor-behind-resolve.sh` (colocated with this skill at `$CLAUDE_PLUGIN_ROOT/skills/implement/scripts/monitor-behind-resolve.sh`) so its upstream-step error handling is unit-testable. The outer monitor below shells out to it on each BEHIND tick. The recipe asserts `$CLAUDE_PLUGIN_ROOT` is set on entry so the failure mode is a single targeted error message rather than a `bash: /skills/implement/scripts/monitor-behind-resolve.sh: No such file or directory` from the substitution producing an empty path.
 
 ```bash
 #!/usr/bin/env bash
@@ -1009,6 +1009,12 @@ The BEHIND auto-resolve subroutine is factored out into `scripts/monitor-behind-
 # Phase 5b shell monitor: drive a PR to merge, escalating to mini-agents on judgment cases.
 #
 set -uo pipefail  # NOT -e: a single failed gh call shouldn't kill the loop.
+
+# The BEHIND auto-resolve shells out to a helper colocated with this skill;
+# fail loudly here if the env var that resolves it is not set rather than
+# letting `bash ""/skills/implement/scripts/...` produce a confusing
+# no-such-file error on every BEHIND tick.
+: "${CLAUDE_PLUGIN_ROOT:?CLAUDE_PLUGIN_ROOT must be set; the BEHIND auto-resolve helper is colocated with this skill at \$CLAUDE_PLUGIN_ROOT/skills/implement/scripts/monitor-behind-resolve.sh}"
 
 pr="${1:?pr number required}"
 branch="${2:?pr branch required}"

--- a/plugins/workflow/skills/implement/scripts/monitor-behind-resolve.sh
+++ b/plugins/workflow/skills/implement/scripts/monitor-behind-resolve.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+# Phase 5b BEHIND auto-resolve subroutine. Runs the local-merge catch-up
+# (`gh repo clone` → `git fetch` → `git merge` → `git push`) for a PR whose
+# `mergeStateStatus` is `BEHIND`, emitting one event line on stdout to be
+# routed by the outer monitor loop.
+#
+# Emits one of:
+#   BEHIND_RESOLVED <pr#>                          -- push landed, branch caught up.
+#   BEHIND_RESOLVE_FAILED <pr#> <reason>           -- push was rejected (PAT scope, etc.).
+#   MONITOR_DEGRADED <pr#> <step> <reason>         -- an upstream step (clone/fetch/merge)
+#                                                     failed. Deduplicated per
+#                                                     `<step>:<pr>` via the dedupe
+#                                                     file so a persistent failure
+#                                                     surfaces once per monitor session.
+#
+# Returns 0 in all cases; emits exactly one event per invocation (or zero, in
+# the case of a deduplicated MONITOR_DEGRADED that's already been surfaced, or
+# a `git merge` that conflicts and falls through to the outer loop's CONFLICT
+# detection on the next tick).
+#
+# Usage: monitor-behind-resolve.sh <pr#> <pr-branch> <base-branch> <dedupe-file>
+#
+# The dedupe file is shared with the parent monitor process (which created it
+# with `mktemp`) and lives for the lifetime of that monitor. Each line is a
+# `<step>:<pr>` marker; the helper appends on first failure and short-circuits
+# on subsequent ones so the orchestrator gets exactly one MONITOR_DEGRADED per
+# `<step>:<pr>` per session.
+
+set -uo pipefail  # NOT -e: we surface failures as events, not exit codes.
+
+pr="${1:?pr number required}"
+branch="${2:?pr branch required}"
+base="${3:?base branch required}"
+dedupe_file="${4:?dedupe file path required}"
+
+emit() { printf '%s\n' "$*"; }
+
+# Collapse multi-line stderr into a single space-separated line so the event
+# stays on one line for the Monitor tool's per-line notification surface.
+collapse() {
+  printf '%s' "$1" | tr '\n\t' '  ' | sed 's/  */ /g' | sed 's/^ //; s/ $//'
+}
+
+# Emit a MONITOR_DEGRADED event at most once per <step>:<pr> per monitor
+# session. The dedupe file is the parent monitor's tempfile; we read it to
+# check and append to it on first emit. Concurrency is fine here -- the outer
+# monitor only invokes this helper at most once per tick, sequentially.
+emit_degraded_once() {
+  local step="$1" reason="$2"
+  local marker="${step}:${pr}"
+  if [[ -f "$dedupe_file" ]] && grep -Fxq "$marker" "$dedupe_file"; then
+    return 0
+  fi
+  emit "MONITOR_DEGRADED $pr $step $(collapse "$reason")"
+  printf '%s\n' "$marker" >>"$dedupe_file"
+}
+
+# Run the catch-up in a subshell so the `cd` into the tempdir doesn't leak
+# back to the caller. The dedupe file lives outside the subshell (passed by
+# path), so writes survive subshell teardown.
+(
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' EXIT
+  cd "$tmpdir" || exit 0
+
+  # Clone. `gh repo view` is inside the substitution -- if it fails the clone
+  # will too, so capturing the clone failure subsumes both cases.
+  clone_err=$(gh repo clone \
+    "$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1)" \
+    repo -- --branch "$branch" --depth 50 2>&1 >/dev/null)
+  clone_rc=$?
+  if [[ $clone_rc -ne 0 ]]; then
+    emit_degraded_once clone "$clone_err"
+    exit 0
+  fi
+
+  cd repo || exit 0
+
+  # Fetch the base branch.
+  fetch_err=$(git fetch origin "$base" 2>&1 >/dev/null)
+  fetch_rc=$?
+  if [[ $fetch_rc -ne 0 ]]; then
+    emit_degraded_once fetch "$fetch_err"
+    exit 0
+  fi
+
+  # Merge the base branch into the PR branch.
+  merge_err=$(git merge --no-edit "origin/$base" 2>&1 >/dev/null)
+  merge_rc=$?
+  if [[ $merge_rc -ne 0 ]]; then
+    # A merge can fail two ways: an actual conflict (which we deliberately
+    # leave for the outer loop's CONFLICT path to surface on the next tick),
+    # or a hard merge error (e.g. `merge: refusing to merge unrelated
+    # histories`, missing ref). Heuristic: if `git ls-files -u` shows
+    # unmerged paths, this is a conflict -- abort and let the outer loop
+    # handle it. Otherwise it's a hard failure -- emit MONITOR_DEGRADED.
+    if git ls-files -u 2>/dev/null | grep -q .; then
+      git merge --abort >/dev/null 2>&1 || true
+    else
+      emit_degraded_once merge "$merge_err"
+    fi
+    exit 0
+  fi
+
+  # Push. Capture stderr so push-specific failures (PAT scope, branch
+  # protection rejection) keep emitting BEHIND_RESOLVE_FAILED -- this is the
+  # pre-existing surfacing contract and intentionally distinct from
+  # MONITOR_DEGRADED.
+  push_err=$(git push origin "$branch" 2>&1 >/dev/null)
+  push_rc=$?
+  if [[ $push_rc -eq 0 ]]; then
+    emit "BEHIND_RESOLVED $pr"
+  else
+    emit "BEHIND_RESOLVE_FAILED $pr $(collapse "$push_err")"
+  fi
+)

--- a/plugins/workflow/skills/implement/scripts/monitor-behind-resolve.sh
+++ b/plugins/workflow/skills/implement/scripts/monitor-behind-resolve.sh
@@ -27,7 +27,14 @@
 # on subsequent ones so the orchestrator gets exactly one MONITOR_DEGRADED per
 # `<step>:<pr>` per session.
 
-set -uo pipefail  # NOT -e: we surface failures as events, not exit codes.
+set -uo pipefail
+# NOTE: Deliberate deviation from the project bash convention `set -euo
+# pipefail` (documented in `~/.claude/CLAUDE.md`). `-e` is omitted because
+# the helper's contract is to capture non-zero exit codes from `gh` / `git`
+# and surface them as `MONITOR_DEGRADED` / `BEHIND_RESOLVE_FAILED` event
+# lines. Re-adding `-e` would silently break the failure-surfacing contract
+# -- the script would die on the first `gh` failure rather than emitting
+# the corresponding event. Do not "fix" this back to `-euo pipefail`.
 
 pr="${1:?pr number required}"
 branch="${2:?pr branch required}"

--- a/plugins/workflow/skills/implement/scripts/tests/test-monitor-behind-resolve.sh
+++ b/plugins/workflow/skills/implement/scripts/tests/test-monitor-behind-resolve.sh
@@ -82,6 +82,17 @@ case "$1 $2" in
       printf 'gh repo clone: permission denied\n' >&2
       exit 1
     fi
+    # The 3rd positional is the repo argument the helper interpolated from
+    # `gh repo view`. If the view stub failed, the captured stderr ends up
+    # here as a bogus repo name -- mirror real `gh repo clone` and reject
+    # anything that does not look like `owner/repo`. This is what makes the
+    # gh-repo-view-folded-into-clone contract actually observable in the
+    # test fixture.
+    repo_arg="$3"
+    if [[ ! "$repo_arg" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+      printf 'gh repo clone: invalid repository %q\n' "$repo_arg" >&2
+      exit 1
+    fi
     # Success: create a `repo` dir so the helper's `cd repo` succeeds.
     mkdir -p repo
     cd repo
@@ -118,7 +129,11 @@ case "\$1" in
     exit 0
     ;;
   merge)
-    if [[ "\$2" == "--abort" ]]; then exit 0; fi
+    if [[ "\$2" == "--abort" ]]; then
+      # Record the abort call so tests can assert it was invoked.
+      : >"\${state_dir}/merge_aborted"
+      exit 0
+    fi
     mode="\$(cat "\${state_dir}/merge_mode" 2>/dev/null || echo ok)"
     case "\$mode" in
       ok)       exit 0 ;;
@@ -227,6 +242,12 @@ rm -rf "$sandbox"
 # through to the outer loop's CONFLICT path on the next tick. This is the
 # key contract distinguishing "auto-resolve degraded" from "auto-resolve
 # decided not to escalate this tick".
+#
+# Also pin two adjacent contracts that a future regression could quietly
+# break: (1) `git merge --abort` is invoked so the working tree is clean
+# for the next tick, and (2) the dedupe file stays empty so a transient
+# conflict does not consume the `merge:<pr>` slot and silently swallow a
+# later hard-merge-error event for the same PR.
 sandbox=$(make_sandbox)
 dedupe="$sandbox/dedupe"; : >"$dedupe"
 printf 'conflict\n' >"$sandbox/state/merge_mode"
@@ -236,6 +257,15 @@ assert_not_contains "merge-conflict tick does NOT emit MONITOR_DEGRADED" \
   "MONITOR_DEGRADED" "$out"
 assert_not_contains "merge-conflict tick does NOT emit BEHIND_RESOLVED either" \
   "BEHIND_RESOLVED" "$out"
+if [[ -f "$sandbox/state/merge_aborted" ]]; then
+  abort_called=true
+else
+  abort_called=false
+fi
+assert_eq "merge-conflict tick calls git merge --abort" \
+  "true" "$abort_called"
+assert_eq "merge-conflict tick leaves dedupe file untouched" \
+  "" "$(cat "$dedupe")"
 rm -rf "$sandbox"
 
 # --- Test 6: success path emits BEHIND_RESOLVED, no MONITOR_DEGRADED.
@@ -263,6 +293,24 @@ assert_contains "BEHIND_RESOLVE_FAILED reason includes captured stderr" \
   "workflow" "$out"
 assert_not_contains "push failure does NOT emit MONITOR_DEGRADED" \
   "MONITOR_DEGRADED" "$out"
+rm -rf "$sandbox"
+
+# --- Test 8: `gh repo view` failure surfaces as MONITOR_DEGRADED clone.
+# Pins the design decision documented in the PR body: `gh repo view` is
+# folded into the `clone` step because the view call is an argument
+# substitution to clone -- if view fails the clone arg is corrupt and the
+# clone fails, capturing both. `clone_mode=ok` here so the clone-stub-side
+# explicit-fail path is NOT what surfaces the failure -- it has to come
+# from the view-corrupted repo arg flowing into the clone.
+sandbox=$(make_sandbox)
+dedupe="$sandbox/dedupe"; : >"$dedupe"
+printf 'fail\n' >"$sandbox/state/view_mode"
+out=$(run_helper "$sandbox" 951 feature/v main "$dedupe" 2>&1)
+
+assert_contains "gh repo view failure surfaces as MONITOR_DEGRADED clone" \
+  "MONITOR_DEGRADED 951 clone" "$out"
+assert_contains "view-via-clone failure reason carries the clone-side stderr" \
+  "invalid repository" "$out"
 rm -rf "$sandbox"
 
 if (( failed != 0 )); then

--- a/plugins/workflow/skills/implement/scripts/tests/test-monitor-behind-resolve.sh
+++ b/plugins/workflow/skills/implement/scripts/tests/test-monitor-behind-resolve.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+
+# Regression tests for the Phase 5b BEHIND auto-resolve helper
+# (`monitor-behind-resolve.sh`). Confirms each upstream step
+# (`gh repo clone` / `git fetch` / `git merge`) emits a
+# `MONITOR_DEGRADED <pr> <step> <reason>` event on failure, that the
+# `<step>:<pr>` dedupe survives across invocations sharing the same
+# dedupe file, and that the pre-existing `BEHIND_RESOLVED` /
+# `BEHIND_RESOLVE_FAILED` push-specific paths are unchanged.
+#
+# The helper shells out to `gh` and `git`. Tests inject stubs via PATH:
+# a per-test stub directory with executable `gh` and `git` scripts that
+# read mode-flag files written by the test to decide whether to exit 0
+# or fail with a canned message.
+#
+# Run: bash plugins/workflow/skills/implement/scripts/tests/test-monitor-behind-resolve.sh
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper="${here}/../monitor-behind-resolve.sh"
+
+failed=0
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    printf 'ok   %s\n' "$name"
+  else
+    printf 'FAIL %s\n      expected: %q\n      actual:   %q\n' \
+      "$name" "$expected" "$actual"
+    failed=1
+  fi
+}
+
+assert_contains() {
+  local name="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    printf 'ok   %s\n' "$name"
+  else
+    printf 'FAIL %s\n      expected to contain: %q\n      actual:              %q\n' \
+      "$name" "$needle" "$haystack"
+    failed=1
+  fi
+}
+
+assert_not_contains() {
+  local name="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    printf 'ok   %s\n' "$name"
+  else
+    printf 'FAIL %s\n      expected NOT to contain: %q\n      actual:                  %q\n' \
+      "$name" "$needle" "$haystack"
+    failed=1
+  fi
+}
+
+# Each test gets a fresh sandbox: a stub bin dir on PATH, a state dir
+# whose files the stubs read to decide their behaviour, and a dedupe
+# file the helper writes to.
+make_sandbox() {
+  local sandbox; sandbox=$(mktemp -d)
+  mkdir -p "$sandbox/bin" "$sandbox/state"
+
+  # `gh` stub. Two subcommands matter:
+  #   `gh repo view --json nameWithOwner -q .nameWithOwner` -> prints "owner/repo"
+  #   `gh repo clone <repo> repo -- ...`                    -> reads state/clone_mode
+  cat >"$sandbox/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -uo pipefail
+state_dir="${STATE_DIR}"
+case "$1 $2" in
+  "repo view")
+    if [[ "$(cat "${state_dir}/view_mode" 2>/dev/null || echo ok)" == "fail" ]]; then
+      printf 'gh repo view: rate-limited\n' >&2
+      exit 1
+    fi
+    printf 'owner/repo\n'
+    ;;
+  "repo clone")
+    if [[ "$(cat "${state_dir}/clone_mode" 2>/dev/null || echo ok)" == "fail" ]]; then
+      printf 'gh repo clone: permission denied\n' >&2
+      exit 1
+    fi
+    # Success: create a `repo` dir so the helper's `cd repo` succeeds.
+    mkdir -p repo
+    cd repo
+    git init -q
+    git config user.email test@example.com
+    git config user.name test
+    git commit --allow-empty -qm initial
+    ;;
+  *)
+    printf 'gh stub: unhandled args: %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+STUB
+  chmod +x "$sandbox/bin/gh"
+
+  # `git` stub. The helper invokes `git fetch`, `git merge`, `git ls-files`,
+  # `git push`, `git init`, `git config`, `git commit`. We need real
+  # behaviour from `git init` / `config` / `commit` (used by the `gh repo
+  # clone` stub above), so we delegate to the real git binary for those
+  # and only intercept the four commands the helper itself runs.
+  real_git=$(command -v git)
+  cat >"$sandbox/bin/git" <<STUB
+#!/usr/bin/env bash
+set -uo pipefail
+state_dir="\${STATE_DIR}"
+real_git="${real_git}"
+case "\$1" in
+  fetch)
+    if [[ "\$(cat "\${state_dir}/fetch_mode" 2>/dev/null || echo ok)" == "fail" ]]; then
+      printf 'fatal: could not read from remote\n' >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  merge)
+    if [[ "\$2" == "--abort" ]]; then exit 0; fi
+    mode="\$(cat "\${state_dir}/merge_mode" 2>/dev/null || echo ok)"
+    case "\$mode" in
+      ok)       exit 0 ;;
+      conflict)
+        # Simulate an unmerged path so the helper's ls-files check
+        # detects a real conflict and falls through to the outer loop.
+        : >"\${state_dir}/has_conflict"
+        printf 'CONFLICT (content): merge conflict in foo\n' >&2
+        exit 1
+        ;;
+      hardfail)
+        printf 'fatal: refusing to merge unrelated histories\n' >&2
+        exit 128
+        ;;
+    esac
+    ;;
+  ls-files)
+    if [[ "\$2" == "-u" && -f "\${state_dir}/has_conflict" ]]; then
+      printf '100644 abc 1\tfoo\n'
+    fi
+    exit 0
+    ;;
+  push)
+    if [[ "\$(cat "\${state_dir}/push_mode" 2>/dev/null || echo ok)" == "fail" ]]; then
+      printf 'remote: refusing to allow PAT to create or update workflow\n' >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  *)
+    exec "\$real_git" "\$@"
+    ;;
+esac
+STUB
+  chmod +x "$sandbox/bin/git"
+
+  printf '%s\n' "$sandbox"
+}
+
+run_helper() {
+  local sandbox="$1" pr="$2" branch="$3" base="$4" dedupe_file="$5"
+  STATE_DIR="$sandbox/state" PATH="$sandbox/bin:$PATH" \
+    bash "$helper" "$pr" "$branch" "$base" "$dedupe_file"
+}
+
+# --- Test 1: clone failure emits MONITOR_DEGRADED clone, deduped on second call.
+sandbox=$(make_sandbox)
+dedupe="$sandbox/dedupe"; : >"$dedupe"
+printf 'fail\n' >"$sandbox/state/clone_mode"
+out1=$(run_helper "$sandbox" 451 feature/x main "$dedupe" 2>&1)
+out2=$(run_helper "$sandbox" 451 feature/x main "$dedupe" 2>&1)
+
+assert_contains \
+  "clone failure emits MONITOR_DEGRADED clone with reason" \
+  "MONITOR_DEGRADED 451 clone" "$out1"
+assert_contains \
+  "clone failure reason includes the captured stderr" \
+  "permission denied" "$out1"
+assert_eq \
+  "second invocation with same dedupe file emits nothing (dedupe holds)" \
+  "" "$out2"
+assert_eq \
+  "dedupe file records clone:451 marker" \
+  "clone:451" "$(cat "$dedupe")"
+rm -rf "$sandbox"
+
+# --- Test 2: clone failure for pr 451 does NOT suppress clone failure for pr 452
+# (dedupe is per `<step>:<pr>`, not per step alone).
+sandbox=$(make_sandbox)
+dedupe="$sandbox/dedupe"; : >"$dedupe"
+printf 'fail\n' >"$sandbox/state/clone_mode"
+out1=$(run_helper "$sandbox" 451 feature/x main "$dedupe" 2>&1)
+out2=$(run_helper "$sandbox" 452 feature/y main "$dedupe" 2>&1)
+
+assert_contains "first PR clone failure surfaces" \
+  "MONITOR_DEGRADED 451 clone" "$out1"
+assert_contains "second PR clone failure also surfaces (different pr#)" \
+  "MONITOR_DEGRADED 452 clone" "$out2"
+rm -rf "$sandbox"
+
+# --- Test 3: fetch failure emits MONITOR_DEGRADED fetch.
+sandbox=$(make_sandbox)
+dedupe="$sandbox/dedupe"; : >"$dedupe"
+printf 'fail\n' >"$sandbox/state/fetch_mode"
+out=$(run_helper "$sandbox" 700 feature/z main "$dedupe" 2>&1)
+
+assert_contains "fetch failure emits MONITOR_DEGRADED fetch" \
+  "MONITOR_DEGRADED 700 fetch" "$out"
+assert_contains "fetch failure reason includes captured stderr" \
+  "could not read from remote" "$out"
+rm -rf "$sandbox"
+
+# --- Test 4: hard merge error (unrelated histories) emits MONITOR_DEGRADED merge.
+sandbox=$(make_sandbox)
+dedupe="$sandbox/dedupe"; : >"$dedupe"
+printf 'hardfail\n' >"$sandbox/state/merge_mode"
+out=$(run_helper "$sandbox" 800 feature/q main "$dedupe" 2>&1)
+
+assert_contains "hard merge error emits MONITOR_DEGRADED merge" \
+  "MONITOR_DEGRADED 800 merge" "$out"
+assert_contains "merge failure reason includes captured stderr" \
+  "unrelated histories" "$out"
+rm -rf "$sandbox"
+
+# --- Test 5: a real merge conflict does NOT emit MONITOR_DEGRADED -- it falls
+# through to the outer loop's CONFLICT path on the next tick. This is the
+# key contract distinguishing "auto-resolve degraded" from "auto-resolve
+# decided not to escalate this tick".
+sandbox=$(make_sandbox)
+dedupe="$sandbox/dedupe"; : >"$dedupe"
+printf 'conflict\n' >"$sandbox/state/merge_mode"
+out=$(run_helper "$sandbox" 801 feature/q main "$dedupe" 2>&1)
+
+assert_not_contains "merge-conflict tick does NOT emit MONITOR_DEGRADED" \
+  "MONITOR_DEGRADED" "$out"
+assert_not_contains "merge-conflict tick does NOT emit BEHIND_RESOLVED either" \
+  "BEHIND_RESOLVED" "$out"
+rm -rf "$sandbox"
+
+# --- Test 6: success path emits BEHIND_RESOLVED, no MONITOR_DEGRADED.
+sandbox=$(make_sandbox)
+dedupe="$sandbox/dedupe"; : >"$dedupe"
+out=$(run_helper "$sandbox" 900 feature/r main "$dedupe" 2>&1)
+
+assert_contains "success path emits BEHIND_RESOLVED" \
+  "BEHIND_RESOLVED 900" "$out"
+assert_not_contains "success path emits no MONITOR_DEGRADED" \
+  "MONITOR_DEGRADED" "$out"
+rm -rf "$sandbox"
+
+# --- Test 7: push failure path is unchanged -- emits BEHIND_RESOLVE_FAILED,
+# not MONITOR_DEGRADED. This guards the acceptance criterion that
+# BEHIND_RESOLVED / BEHIND_RESOLVE_FAILED remain push-specific.
+sandbox=$(make_sandbox)
+dedupe="$sandbox/dedupe"; : >"$dedupe"
+printf 'fail\n' >"$sandbox/state/push_mode"
+out=$(run_helper "$sandbox" 901 feature/r main "$dedupe" 2>&1)
+
+assert_contains "push failure emits BEHIND_RESOLVE_FAILED" \
+  "BEHIND_RESOLVE_FAILED 901" "$out"
+assert_contains "BEHIND_RESOLVE_FAILED reason includes captured stderr" \
+  "workflow" "$out"
+assert_not_contains "push failure does NOT emit MONITOR_DEGRADED" \
+  "MONITOR_DEGRADED" "$out"
+rm -rf "$sandbox"
+
+if (( failed != 0 )); then
+  printf '\nFAIL: one or more assertions failed.\n' >&2
+  exit 1
+fi
+
+printf '\nAll monitor-behind-resolve assertions passed.\n'


### PR DESCRIPTION
## Summary

The Phase 5b shell monitor's BEHIND auto-resolve subshell silently swallowed upstream-step failures: each of `gh repo clone`, `git fetch`, and `git merge` ended in `|| exit 0`, so any failure produced no event. Only `git push` emitted `BEHIND_RESOLVE_FAILED`; everything before it failed invisibly. On 2026-05-01 the user hit this across two PRs whose BEHIND state never cleared with no `BEHIND_RESOLVED` and no `BEHIND_RESOLVE_FAILED` ever firing -- diagnosis had to be by hand. (See #96 for the most common root cause, `gh repo view` failing in tmpdir.)

Each upstream step now captures stderr and emits `MONITOR_DEGRADED <pr#> <step> <reason>` on failure (`<step>` is `clone` / `fetch` / `merge`). Each `<step>:<pr>` combination is deduped via a tempfile that lives for the monitor's lifetime so a persistent failure surfaces exactly once per session, not once per poll.

- The auto-resolve subroutine is factored out into `scripts/monitor-behind-resolve.sh` so its error handling is unit-testable; the outer SKILL.md recipe now shells out to it on each BEHIND tick.
- The orchestrator event-routing table gets a `MONITOR_DEGRADED` row: surface to user, park the PR, monitor keeps polling (the failure may self-recover; dedupe stops chat spam).
- Tests live alongside the helper at `tests/test-monitor-behind-resolve.sh` and exercise each step's failure path, the per-`<step>:<pr>` dedupe (including that it does not leak across PRs), the merge-conflict-vs-hard-error split, and the unchanged push-specific paths.

### Design notes

- **`gh repo view` is folded into `clone`.** The view call is an argument substitution to the clone -- if view fails the clone fails too -- so capturing clone stderr subsumes both. (Issue body listed view separately; on inspection of the recipe a separate event would always be redundant.)
- **Merge-conflict vs hard merge error.** A `git merge` that produces an actual conflict is not surfaced as `MONITOR_DEGRADED merge` -- it falls through to the outer loop's CONFLICT path on the next tick, same as before, so the conflict-resolution mini-agent gets dispatched. Only hard merge errors (e.g. `refusing to merge unrelated histories`) emit `MONITOR_DEGRADED merge`. Heuristic: if `git ls-files -u` shows unmerged paths, treat as conflict; otherwise hard error.
- **Dedupe lives in a tempfile, not a bash variable.** The auto-resolve runs in a subshell and (now) in its own helper process; a parent-shell variable wouldn't survive either boundary. The outer monitor `mktemp`s the file, traps cleanup on EXIT, and passes the path to the helper.

## Test plan

- [ ] `bash plugins/workflow/skills/implement/scripts/tests/test-monitor-behind-resolve.sh` -- all 17 assertions pass.
- [ ] `bash plugins/workflow/skills/implement/scripts/tests/test-phase15-conventions.sh` -- existing tests still pass (no regression).
- [ ] Manual eyeball: SKILL.md routing-table row for `MONITOR_DEGRADED` reads correctly and is consistent with the surrounding `BEHIND_RESOLVED` / `BEHIND_RESOLVE_FAILED` rows.
- [ ] Manual eyeball: chat-relay filter (line 758) lists `MONITOR_DEGRADED` alongside the other Phase 5b events the user is meant to see.

Closes #103