### PR TITLE
feat(workflow): gate BEHIND auto-resolve, defer to bot, cap concurrency

### DIFF
--- a/plugins/workflow/skills/implement/SKILL.md
+++ b/plugins/workflow/skills/implement/SKILL.md
@@ -226,6 +226,7 @@ The emitted block surfaces:
 - **Labels at merge time** — a histogram of every label seen across the sample (label → `<n>/<sample-size>`), so the dispatched agent can spot consistently-applied ones (`automerge`, `no changelog`, etc.).
 - **Manual changelog entries** — required / occasional / not observed, computed from how many recent PRs touched a `changelog/@unreleased/pr-<N>-<slug>.yml` file.
 - **Merge mechanism** — emitted as the `Merge mechanism:` trailer. The orchestrator's Phase 5 step 5 LGTM / `READY_TO_MERGE` branches parse this line to decide which merge-handoff command to run. Three possible values, picked in this order: (1) `apply <label> label (merge-bot picks it up)` — emitted when the two-signal label-triggered merge-bot heuristic fires (a workflow listens to `pull_request: types: [labeled]` with a label-name guard, **and** that label appears on at least half of the recent merged PRs); (2) `gh pr merge --auto --squash` — emitted when the merge-bot heuristic doesn't fire and the script's `allow_auto_merge` probe (`gh api repos/<owner>/<repo> --jq '.allow_auto_merge'`) returns `true`; (3) `gh pr merge --squash` — emitted when the merge-bot heuristic doesn't fire **and** the probe returns `false` (or fails). The third branch exists because GitHub auto-merge is a per-repository setting: when it's disabled, `gh pr merge --auto --squash` fails with the GraphQL error `Auto merge is not allowed for this repository (enablePullRequestAutoMerge)` — `allow_auto_merge: false` is the cause, that error is the symptom. Emitting `gh pr merge --squash` (immediate squash-merge, no `--auto` flag) up-front avoids the round-trip and the per-PR hand-edit fallback. **The trailer is consumed at the post-review automerge gate (Phase 5 step 5), not earlier in the pipeline** — the implementing agent does not parse it, and Phase 1.5 itself never triggers a merge. Snapshotting the value at intake time keeps a single deterministic answer for the whole run; the orchestrator only acts on it once review (and address-review, if needed) has completed.
+- **Project BEHIND handling** — emitted as the `Project BEHIND handling: yes|no` trailer (above the `Merge mechanism:` line). `yes` when any workflow file in `.github/workflows/` calls `PUT /pulls/{n}/update-branch` (recognised by the literal `update-branch` substring) or branches on `mergeStateStatus`/`mergeable_state` against `BEHIND`/`behind`; `no` otherwise. Consumed by Phase 5b: when `yes`, the orchestrator launches the shell monitor with `MONITOR_PROJECT_HANDLES_BEHIND=yes` and the monitor skips its own BEHIND auto-resolve, deferring catch-up to the project-side merge-bot. Without this trailer the monitor and the project's bot would both run local-merge / `update-branch` in parallel — racing each other to update the PR head and (because the monitor doesn't gate on CI-green) restarting in-flight CI cycles.
 
 If the helper script is unavailable for any reason (e.g. the plugin install is corrupted), the orchestrator can fall back to running the steps inline — but treat that as a degraded path and flag it. The script's output is the contract; the orchestrator's merge handoff depends on the `Merge mechanism:` trailer being present.
 
@@ -992,7 +993,9 @@ When step 5 of the Phase 5 execution loop sets automerge (after the warm impleme
    - `gh pr merge <pr#> --auto --squash` when the repo has GitHub auto-merge enabled (`allow_auto_merge: true`). The Phase 5b monitor observes `MERGED` once the merge lands. **Note:** in a no-CI repo, this command resolves synchronously — the merge lands the moment automerge is enabled. That's why the gate above must hold *before* this command runs; once it runs, there is no further opportunity for review to intervene.
    - `gh pr merge <pr#> --squash` (immediate squash-merge, no `--auto` flag) when the repo has GitHub auto-merge disabled (`allow_auto_merge: false`). This is the primary command for that branch — not a fallback — because `gh pr merge --auto --squash` on such a repo fails with the GraphQL error `Auto merge is not allowed for this repository (enablePullRequestAutoMerge)`. The Phase 5b monitor observes `MERGED` on the next poll. The gate-before-command rule applies the same way: this command also resolves synchronously.
 2. Mark the issue as `automerge_set` in internal state. The implementing-agent slot frees here — the warm agent terminated with `READY_TO_MERGE`, the orchestrator just ran the merge handoff, and the next eligible issue can be picked up. (Cap=3 binds through merge handoff per Operating principles § "Concurrency cap: 3"; this is the moment that binding releases.)
-3. Launch the **shell monitor** (below) for that PR via the `Monitor` tool. The monitor's stdout is an event stream the orchestrator consumes.
+3. Launch the **shell monitor** (below) for that PR via the `Monitor` tool. The monitor's stdout is an event stream the orchestrator consumes. Pass the session's identity and the project's BEHIND-handling capability through env vars:
+   - `MONITOR_SESSION_ID=<session-id>` — the orchestrator's `wfi-...` session ID. The monitor uses this to scope the cross-PR `flock`-based BEHIND auto-resolve concurrency cap to a single workflow run (lockfile path: `$HOME/.claude/state/workflow-implement/<session-id>.behind-resolve.lock`). If unset, the lock falls back to `default`, which still bounds a single-PR run but lets parallel sessions step on each other — populate it from the orchestrator's session state when launching.
+   - `MONITOR_PROJECT_HANDLES_BEHIND=yes|no` — read directly from Phase 1.5's `Project BEHIND handling:` trailer (snapshotted in dispatch context, same place the `Merge mechanism:` line is read). When `yes`, the monitor skips its own BEHIND auto-resolve block entirely and lets the project-side merge-bot catch up the branch (the bot's design — wait for CI green, then update if BEHIND, then re-trigger CI on the merge commit — already handles this; running the monitor's auto-resolve in parallel races the bot and restarts in-flight CI cycles). The monitor still polls and emits all other events (`MERGED`, `CONFLICT`, `CI_FAILURE`, `NEW_COMMENT`, `STALLED_GREEN`); only the BEHIND branch is suppressed.
 4. Continue the Phase 5 execution loop — the slot is already free; pick up the next eligible issue if there is one.
 
 ### Shell monitor recipe
@@ -1021,6 +1024,26 @@ branch="${2:?pr branch required}"
 base="${3:-main}"
 poll="${POLL_INTERVAL:-45}"  # seconds between polls.
 stall_threshold="${STALL_THRESHOLD_SECONDS:-180}"  # first STALLED_GREEN emit.
+
+# Defer the BEHIND auto-resolve to the project's merge-bot when Phase 1.5
+# detected one (a workflow that calls `PUT /pulls/{n}/update-branch` or
+# branches on `mergeStateStatus == 'BEHIND'`). The bot's design — wait for
+# CI green, then update if BEHIND, then re-trigger CI on the merge commit
+# — handles this layer; the monitor running its own auto-resolve in
+# parallel races the bot and restarts in-flight CI cycles.
+project_handles_behind="${MONITOR_PROJECT_HANDLES_BEHIND:-no}"
+
+# Session-wide lockfile for the BEHIND auto-resolve. Bounds parallelism
+# across the orchestrator's monitored set so N simultaneously-BEHIND PRs
+# don't trigger N parallel update-branch+CI cycles when the project does
+# NOT have its own BEHIND-handling. `MONITOR_SESSION_ID` is the
+# orchestrator's `wfi-...` session ID; if unset, fall back to `default` so
+# a standalone monitor invocation still runs but parallel sessions can
+# step on each other (the orchestrator should always populate this).
+session_id="${MONITOR_SESSION_ID:-default}"
+behind_lockdir="$HOME/.claude/state/workflow-implement"
+mkdir -p "$behind_lockdir" 2>/dev/null || true
+behind_lockfile="${behind_lockdir}/${session_id}.behind-resolve.lock"
 
 emit() { printf '%s\n' "$*"; }  # one event per line, line-buffered by default.
 
@@ -1088,9 +1111,31 @@ while :; do
   # via the helper, which also surfaces upstream-step failures (clone /
   # fetch / merge) as MONITOR_DEGRADED so a broken auto-resolve doesn't
   # silently loop the BEHIND state forever.
-  if [[ "$msstatus" == "BEHIND" && "$mergeable" != "CONFLICTING" ]]; then
-    bash "$CLAUDE_PLUGIN_ROOT/skills/implement/scripts/monitor-behind-resolve.sh" \
-      "$pr" "$branch" "$base" "$degraded_dedupe"
+  #
+  # Three gates apply before we invoke the helper:
+  #   1. `project_handles_behind == "yes"`: the project has its own
+  #      merge-bot that handles BEHIND (Phase 1.5 detected an
+  #      `update-branch` API call or `mergeStateStatus == 'BEHIND'`
+  #      handler in a workflow). Defer entirely — the bot's CI-green
+  #      gating is the canonical implementation, and racing it from
+  #      here just restarts in-flight CI cycles.
+  #   2. CI-green precheck (inside the helper): the helper queries
+  #      statusCheckRollup itself and exits 0 silently if any check is
+  #      pending or non-green. Restarting CI by pushing a merge commit
+  #      while the previous run is still in flight slows the merge.
+  #   3. Session-wide flock: only one monitor across the whole
+  #      `/workflow:implement` session can be inside the auto-resolve
+  #      block at a time. Other monitors observing BEHIND simultaneously
+  #      back off silently to the next tick. `flock -n` is non-blocking;
+  #      the lock auto-releases when the subshell exits (helper returns
+  #      or is killed).
+  if [[ "$msstatus" == "BEHIND" && "$mergeable" != "CONFLICTING" \
+        && "$project_handles_behind" != "yes" ]]; then
+    (
+      flock -n 9 || exit 0
+      bash "$CLAUDE_PLUGIN_ROOT/skills/implement/scripts/monitor-behind-resolve.sh" \
+        "$pr" "$branch" "$base" "$degraded_dedupe"
+    ) 9>"$behind_lockfile"
   fi
 
   # ---- DIRTY / CONFLICTING: escalate to conflict-resolution mini-agent. ----
@@ -1174,6 +1219,9 @@ done
 Key behaviours:
 
 - **`BEHIND` auto-resolution stays in-shell.** Uses the same local-merge approach the implementing agent uses (`git fetch origin main && git merge --no-edit origin/main && git push`) — no `update-branch` API call, consistent with the rest of this skill.
+- **BEHIND auto-resolve gates on CI being fully green.** Before invoking the helper, the helper itself queries `statusCheckRollup` and verifies every check has `conclusion ∈ {SUCCESS, SKIPPED, NEUTRAL}`; a pending check (null/empty conclusion) or a non-green resolved conclusion (FAILURE / CANCELLED / TIMED_OUT / etc.) defers the resolve to the next tick (silent no-op — emit nothing). Mirrors the merge-bot.yml `recheck` pattern: don't push a merge commit that restarts the in-flight CI cycle, and don't try to catch up a PR whose CI is failing for non-BEHIND reasons. The empty-rollup case (no CI configured on the PR) is treated as green — there's no cycle to disrupt.
+- **BEHIND auto-resolve defers to project-side merge-bots.** When Phase 1.5's `Project BEHIND handling:` trailer is `yes` (a workflow calls `PUT /pulls/{n}/update-branch` or branches on `mergeStateStatus == 'BEHIND'`), the orchestrator launches the monitor with `MONITOR_PROJECT_HANDLES_BEHIND=yes` and the BEHIND branch is skipped entirely. The bot's design — wait for CI green, then update if BEHIND, then re-trigger CI on the merge commit — already handles this layer; running the monitor's auto-resolve in parallel races the bot and restarts in-flight CI cycles. The monitor still polls and emits all other events (`MERGED`, `CONFLICT`, `CI_FAILURE`, `NEW_COMMENT`, `STALLED_GREEN`).
+- **BEHIND auto-resolve is capped at one in-flight resolve per session.** Across the orchestrator's monitored set, only one Phase 5b monitor can be inside the BEHIND auto-resolve block at a time. Implemented via `flock -n` on `$HOME/.claude/state/workflow-implement/<session-id>.behind-resolve.lock` (lockfile path uses the `MONITOR_SESSION_ID` env var the orchestrator passes at launch — the same `wfi-...` session ID the state file uses). Other monitors observing BEHIND simultaneously back off silently to the next tick rather than emitting a digest line — the orchestrator's regular progress digest already surfaces BEHIND. Lockfile lifetime: one monitor's auto-resolve attempt; the lock auto-releases when the subshell carrying `flock` exits (helper returns or is killed). The lockfile itself persists across runs (no cleanup needed; `flock` only cares about open file descriptors, not file presence). Pairs with cross-PR caps that may exist on the project's merge-bot side — same shape, different layer.
 - **Push failures are surfaced, not swallowed.** `git push` stderr is captured and the exit code is checked. On failure, the monitor emits `BEHIND_RESOLVE_FAILED <pr#> <reason>` instead of `BEHIND_RESOLVED`, so a silently-rejected push (e.g. PAT missing `workflow` scope on `.github/workflows/*` changes) escalates to the user instead of the next tick re-observing BEHIND and looping. `BEHIND_RESOLVED` is only emitted when the push actually landed.
 - **Upstream-step failures are surfaced, not swallowed.** The `gh repo clone` / `git fetch` / `git merge` steps that precede the push each capture their stderr and emit `MONITOR_DEGRADED <pr#> <step> <reason>` on failure (where `<step>` is `clone` / `fetch` / `merge`). Without this surfacing, a broken auto-resolve (e.g. `gh repo view` failing in the monitor's tmpdir, a stale clone token, an unrelated-histories merge error) was invisible to the orchestrator: BEHIND would persist for poll after poll with no event, no `BEHIND_RESOLVED`, no `BEHIND_RESOLVE_FAILED`, and the user had to diagnose by hand. Each `<step>:<pr>` combination emits at most once per monitor session (dedupe lives in the `degraded_dedupe` tempfile) so a persistent failure surfaces exactly once. `gh repo view` is folded into the `clone` step because the view call is a substitution argument to the clone — if view fails the clone fails, and capturing the clone stderr captures both. A `git merge` that produces conflicts (rather than a hard merge error) is *not* surfaced as `MONITOR_DEGRADED merge` — it falls through to the next tick's CONFLICT path so the conflict-resolution mini-agent gets dispatched, same as before.
 - **Transient `gh` failures** (network blips, rate-limit retries) don't crash the loop — `|| true` and an empty-result check keep polling.

--- a/plugins/workflow/skills/implement/scripts/monitor-behind-resolve.sh
+++ b/plugins/workflow/skills/implement/scripts/monitor-behind-resolve.sh
@@ -15,9 +15,30 @@
 #                                                     surfaces once per monitor session.
 #
 # Returns 0 in all cases; emits exactly one event per invocation (or zero, in
-# the case of a deduplicated MONITOR_DEGRADED that's already been surfaced, or
-# a `git merge` that conflicts and falls through to the outer loop's CONFLICT
-# detection on the next tick).
+# the case of a deduplicated MONITOR_DEGRADED that's already been surfaced, a
+# `git merge` that conflicts and falls through to the outer loop's CONFLICT
+# detection on the next tick, or a CI-not-fully-green precheck that defers the
+# resolve to a later tick — see the precheck block below).
+#
+# CI-green precheck: before doing any work, the helper queries
+# `statusCheckRollup` and requires that every check is fully resolved AND
+# fully green (`conclusion ∈ {SUCCESS, SKIPPED, NEUTRAL}`). If any check is
+# still pending (null / IN_PROGRESS conclusion) or has a non-green resolved
+# conclusion (FAILURE / CANCELLED / TIMED_OUT / etc.), the helper exits 0
+# silently — emit nothing, wait for the next tick. This mirrors a
+# project-side merge-bot's `recheck` gate: don't push a merge commit that
+# would restart the in-flight CI cycle, and don't try to catch up a branch
+# whose CI is already failing for non-BEHIND reasons.
+#
+# The precheck queries `gh pr view --json statusCheckRollup` itself rather
+# than accepting the rollup as a 5th positional argument. The duplicate
+# query (the outer monitor already fetches the rollup each tick) costs ~one
+# `gh` call per BEHIND tick — rare in practice, since BEHIND ticks only
+# happen when `main` has moved out from under the PR — and keeps the
+# helper's signature unchanged. Threading the rollup through as a JSON
+# blob argument would tangle the helper's contract with the outer
+# monitor's JSON shape and make standalone invocation harder to reason
+# about.
 #
 # Usage: monitor-behind-resolve.sh <pr#> <pr-branch> <base-branch> <dedupe-file>
 #
@@ -62,6 +83,50 @@ emit_degraded_once() {
   emit "MONITOR_DEGRADED $pr $step $(collapse "$reason")"
   printf '%s\n' "$marker" >>"$dedupe_file"
 }
+
+# CI-green precheck. Defer the local-merge catch-up until the most recent
+# fully-completed CI run is green; otherwise we'd push a merge commit that
+# restarts an in-flight CI cycle (slowing the merge instead of speeding it
+# up) or catch up a PR whose CI is already failing for non-BEHIND reasons
+# (the failure needs human attention, not a branch update).
+#
+# "Fully green" = every check in `statusCheckRollup` has
+# `conclusion ∈ {SUCCESS, SKIPPED, NEUTRAL}`. A null / empty conclusion is
+# treated as pending (still running), which fails the gate. Any other
+# resolved conclusion (FAILURE, CANCELLED, TIMED_OUT, ACTION_REQUIRED,
+# STALE) also fails the gate.
+#
+# The empty-rollup case (no CI configured on the PR) is treated as green
+# — there's no CI cycle to disrupt, and the BEHIND state still needs
+# resolving. This matches how the outer monitor's STALLED_GREEN detector
+# treats an empty rollup.
+#
+# Returns 0 (proceed) iff the rollup is empty or every entry is in the
+# accepted-conclusion set; returns 1 (defer) otherwise. The `gh pr view`
+# call is silenced on failure (network blip, transient API error) and the
+# precheck defers to be safe rather than racing in on stale data.
+ci_fully_green() {
+  local rollup
+  rollup=$(gh pr view "$pr" --json statusCheckRollup --jq '.statusCheckRollup' 2>/dev/null)
+  if [[ -z "$rollup" || "$rollup" == "null" ]]; then
+    # `gh` failed or returned no rollup -- defer to the next tick rather
+    # than acting on missing data.
+    return 1
+  fi
+  # Every entry must have an accepted conclusion. `(.conclusion // "")` so a
+  # null/missing conclusion becomes "" (pending), which is not in the
+  # accepted set and thus fails the gate.
+  jq -e 'all(.[]?; (.conclusion // "") as $c
+            | $c == "SUCCESS" or $c == "SKIPPED" or $c == "NEUTRAL")' \
+    <<<"$rollup" >/dev/null 2>&1
+}
+
+if ! ci_fully_green; then
+  # Silent no-op: wait for the next tick. The outer monitor will re-poll
+  # the rollup and re-invoke us; once CI lands fully-green, the resolve
+  # will proceed.
+  exit 0
+fi
 
 # Run the catch-up in a subshell so the `cd` into the tempdir doesn't leak
 # back to the caller. The dedupe file lives outside the subshell (passed by

--- a/plugins/workflow/skills/implement/scripts/phase15-conventions.sh
+++ b/plugins/workflow/skills/implement/scripts/phase15-conventions.sh
@@ -98,6 +98,43 @@ if [[ "${BASH_SOURCE[0]:-$0}" != "$0" ]]; then
   return 0
 fi
 
+# Probe whether the project's `.github/workflows/` contains a workflow that
+# handles BEHIND. Returns `yes`/`no` on stdout; never exits non-zero (a
+# missing or empty workflow directory is treated as `no`). Wraps the
+# iterate-and-fetch pattern that would otherwise be duplicated between
+# the empty-sample short-circuit and the main-flow loop -- keeping a
+# single network-touching implementation prevents the two paths from
+# silently diverging if the detection signals are extended later (e.g. a
+# third probe added to `phase15_workflow_handles_behind`, or a workflow
+# filename filter added here).
+#
+# Lives below the source-guard so it isn't exposed to the offline tests
+# (the pure-text predicate `phase15_workflow_handles_behind` is the
+# unit-tested layer; this wrapper just sequences the network calls).
+phase15_probe_project_handles_behind() {
+  local probe_repo="$1"
+  local workflows
+  workflows=$(gh api "repos/${probe_repo}/contents/.github/workflows" \
+    --jq '.[]?.name' 2>/dev/null || true)
+  if [[ -z "$workflows" ]]; then
+    printf 'no\n'
+    return 0
+  fi
+  local wf wf_content
+  while IFS= read -r wf; do
+    [[ -z "$wf" ]] && continue
+    [[ "$wf" =~ \.ya?ml$ ]] || continue
+    wf_content=$(gh api "repos/${probe_repo}/contents/.github/workflows/${wf}" \
+      --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)
+    [[ -z "$wf_content" ]] && continue
+    if phase15_workflow_handles_behind "$wf_content"; then
+      printf 'yes\n'
+      return 0
+    fi
+  done <<<"$workflows"
+  printf 'no\n'
+}
+
 repo="${1:?repo required, e.g. aidanns/claude-skills}"
 
 # --- Sample: most recent merged PRs -----------------------------------------
@@ -131,25 +168,9 @@ if (( sample_size == 0 )); then
   # Probe BEHIND handling even on empty-sample repos so the trailer is
   # always present in the emitted block (downstream consumers can rely on
   # the trailer existing rather than having to handle two output shapes).
-  empty_sample_behind="no"
-  empty_sample_workflows=$(gh api "repos/${repo}/contents/.github/workflows" \
-    --jq '.[]?.name' 2>/dev/null || true)
-  if [[ -n "$empty_sample_workflows" ]]; then
-    while IFS= read -r wf; do
-      [[ -z "$wf" ]] && continue
-      [[ "$wf" =~ \.ya?ml$ ]] || continue
-      wf_content=$(gh api "repos/${repo}/contents/.github/workflows/${wf}" \
-        --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)
-      [[ -z "$wf_content" ]] && continue
-      if phase15_workflow_handles_behind "$wf_content"; then
-        empty_sample_behind="yes"
-        break
-      fi
-    done <<<"$empty_sample_workflows"
-  fi
   cat <<EOF
 Current PR conventions (observed): no merged PRs in this repo yet — fall back to project docs (\`CLAUDE.md\`, \`CONTRIBUTING.md\`) for conventions.
-Project BEHIND handling: ${empty_sample_behind}
+Project BEHIND handling: $(phase15_probe_project_handles_behind "$repo")
 Merge mechanism: ${default_merge}
 EOF
   exit 0
@@ -278,7 +299,6 @@ workflows=$(gh api "repos/${repo}/contents/.github/workflows" \
   --jq '.[]?.name' 2>/dev/null || true)
 
 candidate_label=""
-project_handles_behind="no"
 if [[ -n "$workflows" ]]; then
   while IFS= read -r wf; do
     [[ -z "$wf" ]] && continue
@@ -287,27 +307,22 @@ if [[ -n "$workflows" ]]; then
       --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)
     [[ -z "$wf_content" ]] && continue
 
-    # Project BEHIND-handling probe: scans every workflow (independent of
-    # the label-bot probe below) so a project that uses immediate-squash
-    # merge but still has a separate update-branch workflow is detected.
-    # Once we've found one match, skip the further-grep cost on remaining
-    # workflows.
-    if [[ "$project_handles_behind" == "no" ]] \
-       && phase15_workflow_handles_behind "$wf_content"; then
-      project_handles_behind="yes"
-    fi
-
     phase15_workflow_listens_to_labeled "$wf_content" || continue
 
     label=$(phase15_extract_label_guard "$wf_content")
-    if [[ -n "$label" && -z "$candidate_label" ]]; then
+    if [[ -n "$label" ]]; then
       candidate_label="$label"
-      # Don't `break` — keep iterating so the BEHIND probe gets a chance
-      # to fire on workflows we'd otherwise have skipped. The early-out
-      # on `project_handles_behind` above bounds the extra cost.
+      break
     fi
   done <<<"$workflows"
 fi
+
+# Project BEHIND-handling probe. Routed through the shared helper rather
+# than folded into the label-bot loop above so both this branch and the
+# empty-sample short-circuit (above) call exactly one implementation --
+# preventing the two paths from silently diverging if the detection
+# signals are extended later.
+project_handles_behind=$(phase15_probe_project_handles_behind "$repo")
 
 if [[ -n "$candidate_label" ]]; then
   # Cross-check: does the label appear on most recent merged PRs?

--- a/plugins/workflow/skills/implement/scripts/phase15-conventions.sh
+++ b/plugins/workflow/skills/implement/scripts/phase15-conventions.sh
@@ -60,6 +60,38 @@ phase15_extract_label_guard() {
     <<<"$content" | grep -oE "'[^']+'" | head -1 | tr -d "'" || true
 }
 
+# Does this workflow contain a project-side BEHIND-handling step? Two
+# detection signals (either is sufficient):
+#
+#   1. A `PUT /pulls/{n}/update-branch` API call — the canonical way a
+#      merge-bot catches up a stale PR head before merging. Recognised by
+#      a literal `update-branch` substring; the path is consistent across
+#      `gh api`, `curl`, and Octokit invocations.
+#   2. A `mergeStateStatus`/`mergeable_state` reference where the workflow
+#      branches on the value being `BEHIND`/`behind`. Catches workflows
+#      that probe the state explicitly before invoking `update-branch` or
+#      that route to a different remediation. We require both halves
+#      (`mergeStateStatus`/`mergeable_state` *and* `BEHIND`/`behind`) on
+#      the same workflow so an unrelated `mergeable_state == 'clean'`
+#      check or a stray `behind` token elsewhere doesn't false-positive.
+#
+# Returns 0 iff the workflow handles BEHIND, 1 otherwise. Whitespace and
+# casing variants are tolerated where they appear in the wild; the
+# substring-anchored signals are deliberately broad because under-detection
+# (skipping a project-side handler and racing it from the monitor) is the
+# expensive failure mode this trailer is meant to prevent.
+phase15_workflow_handles_behind() {
+  local content="$1"
+  if grep -q 'update-branch' <<<"$content"; then
+    return 0
+  fi
+  if grep -qE 'mergeStateStatus|mergeable_state' <<<"$content" \
+     && grep -qE '\b(BEHIND|behind)\b' <<<"$content"; then
+    return 0
+  fi
+  return 1
+}
+
 # When sourced (e.g. by the regression test), expose only the helpers. Skip
 # argument parsing and all `gh api` calls so the test runs offline.
 if [[ "${BASH_SOURCE[0]:-$0}" != "$0" ]]; then
@@ -96,8 +128,28 @@ if (( sample_size == 0 )); then
   else
     default_merge='gh pr merge --squash'
   fi
+  # Probe BEHIND handling even on empty-sample repos so the trailer is
+  # always present in the emitted block (downstream consumers can rely on
+  # the trailer existing rather than having to handle two output shapes).
+  empty_sample_behind="no"
+  empty_sample_workflows=$(gh api "repos/${repo}/contents/.github/workflows" \
+    --jq '.[]?.name' 2>/dev/null || true)
+  if [[ -n "$empty_sample_workflows" ]]; then
+    while IFS= read -r wf; do
+      [[ -z "$wf" ]] && continue
+      [[ "$wf" =~ \.ya?ml$ ]] || continue
+      wf_content=$(gh api "repos/${repo}/contents/.github/workflows/${wf}" \
+        --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)
+      [[ -z "$wf_content" ]] && continue
+      if phase15_workflow_handles_behind "$wf_content"; then
+        empty_sample_behind="yes"
+        break
+      fi
+    done <<<"$empty_sample_workflows"
+  fi
   cat <<EOF
 Current PR conventions (observed): no merged PRs in this repo yet — fall back to project docs (\`CLAUDE.md\`, \`CONTRIBUTING.md\`) for conventions.
+Project BEHIND handling: ${empty_sample_behind}
 Merge mechanism: ${default_merge}
 EOF
   exit 0
@@ -226,6 +278,7 @@ workflows=$(gh api "repos/${repo}/contents/.github/workflows" \
   --jq '.[]?.name' 2>/dev/null || true)
 
 candidate_label=""
+project_handles_behind="no"
 if [[ -n "$workflows" ]]; then
   while IFS= read -r wf; do
     [[ -z "$wf" ]] && continue
@@ -234,12 +287,24 @@ if [[ -n "$workflows" ]]; then
       --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)
     [[ -z "$wf_content" ]] && continue
 
+    # Project BEHIND-handling probe: scans every workflow (independent of
+    # the label-bot probe below) so a project that uses immediate-squash
+    # merge but still has a separate update-branch workflow is detected.
+    # Once we've found one match, skip the further-grep cost on remaining
+    # workflows.
+    if [[ "$project_handles_behind" == "no" ]] \
+       && phase15_workflow_handles_behind "$wf_content"; then
+      project_handles_behind="yes"
+    fi
+
     phase15_workflow_listens_to_labeled "$wf_content" || continue
 
     label=$(phase15_extract_label_guard "$wf_content")
-    if [[ -n "$label" ]]; then
+    if [[ -n "$label" && -z "$candidate_label" ]]; then
       candidate_label="$label"
-      break
+      # Don't `break` — keep iterating so the BEHIND probe gets a chance
+      # to fire on workflows we'd otherwise have skipped. The early-out
+      # on `project_handles_behind` above bounds the extra cost.
     fi
   done <<<"$workflows"
 fi
@@ -279,5 +344,6 @@ cat <<EOF
 - Labels seen at merge time:
 ${label_hist}
 - ${changelog_line}
+Project BEHIND handling: ${project_handles_behind}
 Merge mechanism: ${merge_mechanism}
 EOF

--- a/plugins/workflow/skills/implement/scripts/tests/fixtures/behind-handler-mergeable-state.yml
+++ b/plugins/workflow/skills/implement/scripts/tests/fixtures/behind-handler-mergeable-state.yml
@@ -1,0 +1,29 @@
+# Companion fixture for issue #100.
+#
+# Captures a workflow that probes BEHIND state explicitly via
+# `mergeStateStatus` / `mergeable_state` rather than calling
+# `update-branch` directly. Some merge-bots branch on the value before
+# routing to a different remediation (e.g. comment + manual escalation
+# rather than auto-update). The Phase 1.5 detector must still emit
+# `Project BEHIND handling: yes` for these so the Phase 5b monitor
+# defers and doesn't race the project's logic.
+
+name: Merge State Audit
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inspect merge state
+        run: |
+          state="$(gh pr view "${PR_NUMBER}" --json mergeStateStatus \
+            --jq '.mergeStateStatus')"
+          if [[ "${state}" == "BEHIND" ]]; then
+            echo "PR is behind base; remediation pending."
+          fi

--- a/plugins/workflow/skills/implement/scripts/tests/fixtures/behind-handler-update-branch.yml
+++ b/plugins/workflow/skills/implement/scripts/tests/fixtures/behind-handler-update-branch.yml
@@ -1,0 +1,27 @@
+# Regression fixture for issue #100.
+#
+# Captures a project-side merge-bot that handles BEHIND by calling
+# `PUT /pulls/{n}/update-branch` (the canonical pattern documented on
+# `aidanns/agent-auth/.github/workflows/merge-bot.yml`). The Phase 1.5
+# `Project BEHIND handling:` trailer must be `yes` for any workflow
+# matching this shape so the Phase 5b monitor knows to defer to the bot.
+
+name: Merge Bot
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_run:
+    workflows: [Test, Check]
+    types: [completed]
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'automerge')
+    steps:
+      - name: Catch up branch when behind
+        run: |
+          gh api --method PUT \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/update-branch" \
+            -f expected_head_sha="${HEAD_SHA}"

--- a/plugins/workflow/skills/implement/scripts/tests/fixtures/no-behind-handler.yml
+++ b/plugins/workflow/skills/implement/scripts/tests/fixtures/no-behind-handler.yml
@@ -1,0 +1,21 @@
+# Negative fixture for issue #100.
+#
+# A standard CI workflow that does not handle BEHIND in any form. The
+# Phase 1.5 detector must emit `Project BEHIND handling: no` for repos
+# whose only workflows match this shape — otherwise the Phase 5b
+# monitor would (incorrectly) skip its in-shell auto-resolve and the PR
+# would silently park behind main.
+
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./run-tests.sh

--- a/plugins/workflow/skills/implement/scripts/tests/test-monitor-behind-resolve.sh
+++ b/plugins/workflow/skills/implement/scripts/tests/test-monitor-behind-resolve.sh
@@ -70,6 +70,42 @@ make_sandbox() {
 set -uo pipefail
 state_dir="${STATE_DIR}"
 case "$1 $2" in
+  "pr view")
+    # Used by the helper's CI-green precheck:
+    #   gh pr view <pr> --json statusCheckRollup --jq '.statusCheckRollup'
+    # The stub reads `state/checks_rollup` to decide what JSON to emit.
+    # File contents map to canned rollups:
+    #   `green`   -> all SUCCESS (proceed).
+    #   `pending` -> one IN_PROGRESS entry (defer).
+    #   `failure` -> one FAILURE entry (defer).
+    #   `mixed`   -> mixed SUCCESS+SKIPPED+NEUTRAL (proceed).
+    #   `empty`   -> empty array (proceed; no CI configured).
+    #   missing/anything else -> default to `green` so existing tests
+    #     that don't set this file see the helper's behaviour unchanged.
+    mode="$(cat "${state_dir}/checks_rollup" 2>/dev/null || echo green)"
+    case "$mode" in
+      pending)
+        printf '[{"name":"build","conclusion":null,"status":"IN_PROGRESS"}]\n'
+        ;;
+      failure)
+        printf '[{"name":"build","conclusion":"FAILURE","status":"COMPLETED"}]\n'
+        ;;
+      mixed)
+        printf '[{"name":"build","conclusion":"SUCCESS","status":"COMPLETED"},{"name":"lint","conclusion":"SKIPPED","status":"COMPLETED"},{"name":"sec","conclusion":"NEUTRAL","status":"COMPLETED"}]\n'
+        ;;
+      empty)
+        printf '[]\n'
+        ;;
+      gh_fail)
+        # Simulate a transient `gh` failure on the precheck path.
+        printf 'gh pr view: api error\n' >&2
+        exit 1
+        ;;
+      *)
+        printf '[{"name":"build","conclusion":"SUCCESS","status":"COMPLETED"}]\n'
+        ;;
+    esac
+    ;;
   "repo view")
     if [[ "$(cat "${state_dir}/view_mode" 2>/dev/null || echo ok)" == "fail" ]]; then
       printf 'gh repo view: rate-limited\n' >&2
@@ -311,6 +347,75 @@ assert_contains "gh repo view failure surfaces as MONITOR_DEGRADED clone" \
   "MONITOR_DEGRADED 951 clone" "$out"
 assert_contains "view-via-clone failure reason carries the clone-side stderr" \
   "invalid repository" "$out"
+rm -rf "$sandbox"
+
+# --- Test 9 (issue #100): CI-pending precheck defers the resolve.
+# When `statusCheckRollup` shows any check still running (null/missing
+# conclusion), the helper must exit silently — no MONITOR_DEGRADED, no
+# BEHIND_RESOLVED, no BEHIND_RESOLVE_FAILED. This guards the merge-bot
+# `recheck` ordering: don't push a merge commit that restarts an
+# in-flight CI cycle.
+sandbox=$(make_sandbox)
+dedupe="$sandbox/dedupe"; : >"$dedupe"
+printf 'pending\n' >"$sandbox/state/checks_rollup"
+out=$(run_helper "$sandbox" 1001 feature/p main "$dedupe" 2>&1)
+
+assert_eq "CI-pending precheck emits no event (silent next-tick deferral)" \
+  "" "$out"
+assert_eq "CI-pending precheck leaves dedupe file untouched" \
+  "" "$(cat "$dedupe")"
+rm -rf "$sandbox"
+
+# --- Test 10 (issue #100): CI-failed precheck also defers the resolve.
+# A non-green resolved conclusion (FAILURE / CANCELLED / TIMED_OUT) means
+# the PR has problems unrelated to BEHIND that need human attention; do
+# not push a merge commit on top of failing CI.
+sandbox=$(make_sandbox)
+dedupe="$sandbox/dedupe"; : >"$dedupe"
+printf 'failure\n' >"$sandbox/state/checks_rollup"
+out=$(run_helper "$sandbox" 1002 feature/f main "$dedupe" 2>&1)
+
+assert_eq "CI-failed precheck emits no event (silent next-tick deferral)" \
+  "" "$out"
+rm -rf "$sandbox"
+
+# --- Test 11 (issue #100): SUCCESS+SKIPPED+NEUTRAL is treated as fully
+# green — the precheck must not be a strict-SUCCESS-only check, since
+# real CI rollups commonly include skipped/neutral entries (e.g. a
+# matrix job that only runs on certain paths).
+sandbox=$(make_sandbox)
+dedupe="$sandbox/dedupe"; : >"$dedupe"
+printf 'mixed\n' >"$sandbox/state/checks_rollup"
+out=$(run_helper "$sandbox" 1003 feature/m main "$dedupe" 2>&1)
+
+assert_contains "SUCCESS+SKIPPED+NEUTRAL rollup proceeds to BEHIND_RESOLVED" \
+  "BEHIND_RESOLVED 1003" "$out"
+rm -rf "$sandbox"
+
+# --- Test 12 (issue #100): empty rollup (no CI configured on the PR)
+# proceeds — there's no in-flight cycle to disrupt and BEHIND still
+# needs resolving. Matches how the outer monitor's STALLED_GREEN
+# detector treats an empty rollup.
+sandbox=$(make_sandbox)
+dedupe="$sandbox/dedupe"; : >"$dedupe"
+printf 'empty\n' >"$sandbox/state/checks_rollup"
+out=$(run_helper "$sandbox" 1004 feature/e main "$dedupe" 2>&1)
+
+assert_contains "empty rollup proceeds to BEHIND_RESOLVED" \
+  "BEHIND_RESOLVED 1004" "$out"
+rm -rf "$sandbox"
+
+# --- Test 13 (issue #100): a transient `gh pr view` failure on the
+# precheck path defers rather than racing in on missing data. The
+# helper must treat gh-failure-during-precheck the same as
+# CI-not-fully-green and exit silently.
+sandbox=$(make_sandbox)
+dedupe="$sandbox/dedupe"; : >"$dedupe"
+printf 'gh_fail\n' >"$sandbox/state/checks_rollup"
+out=$(run_helper "$sandbox" 1005 feature/g main "$dedupe" 2>&1)
+
+assert_eq "transient gh failure on precheck defers silently" \
+  "" "$out"
 rm -rf "$sandbox"
 
 if (( failed != 0 )); then

--- a/plugins/workflow/skills/implement/scripts/tests/test-phase15-conventions.sh
+++ b/plugins/workflow/skills/implement/scripts/tests/test-phase15-conventions.sh
@@ -47,6 +47,17 @@ assert_guard() {
   assert_eq "$name" "$expected" "$actual"
 }
 
+assert_handles_behind() {
+  local name="$1" fixture="$2" expected="$3"
+  local content; content="$(cat "${fixtures}/${fixture}")"
+  if phase15_workflow_handles_behind "$content"; then
+    actual=true
+  else
+    actual=false
+  fi
+  assert_eq "$name" "$expected" "$actual"
+}
+
 # Issue #101: inline-flow `types: [labeled]` plus a multi-line `if:` block
 # whose label-name guard is buried inside an `||` clause. The pre-fix
 # detector missed both halves of this pattern and so emitted the wrong
@@ -73,6 +84,27 @@ assert_guard   "no label guard yields empty extraction" \
 # Negative: workflow does not subscribe to `pull_request: labeled` at all.
 assert_listens "non-pull_request workflow is rejected" \
   "no-pull-request-trigger.yml" false
+
+# Issue #100: project-side BEHIND handlers must be detected so the Phase 5b
+# monitor defers to the bot instead of racing it. Two recognised shapes:
+#   1. `update-branch` API call (canonical merge-bot pattern).
+#   2. Explicit `mergeStateStatus`/`mergeable_state` probe + `BEHIND`
+#      branching (workflows that detect the state but route elsewhere).
+assert_handles_behind "update-branch API call recognised as BEHIND handler" \
+  "behind-handler-update-branch.yml" true
+assert_handles_behind "mergeStateStatus + BEHIND probe recognised as BEHIND handler" \
+  "behind-handler-mergeable-state.yml" true
+
+# Negative: workflow does not handle BEHIND in any form. The detector
+# must NOT mark these as project-handles-BEHIND, otherwise the Phase 5b
+# monitor would silently skip its auto-resolve and the PR would park.
+assert_handles_behind "plain CI workflow is not a BEHIND handler" \
+  "no-behind-handler.yml" false
+# A merge-bot fixture whose label-bot pattern is detected but that has
+# no BEHIND-handling logic must still come back as a non-handler — the
+# two probes are independent.
+assert_handles_behind "label-bot fixture without BEHIND handling is not a BEHIND handler" \
+  "merge-bot-inline-flow.yml" false
 
 if (( failed != 0 )); then
   printf '\nFAIL: one or more assertions failed.\n' >&2


### PR DESCRIPTION
## Summary

Three orthogonal hardening changes to Phase 5b post-automerge monitoring's BEHIND auto-resolve, all surfaced by the 2026-05-01 `/workflow:implement` run on `aidanns/agent-auth#456/#457/#458`:

1. **(a) CI-green gating** — `monitor-behind-resolve.sh` now queries `statusCheckRollup` and defers silently unless every check has `conclusion ∈ {SUCCESS, SKIPPED, NEUTRAL}` (a pending null/IN_PROGRESS or non-green resolved conclusion fails the gate). Mirrors `merge-bot.yml`'s `recheck` pattern: don't push a merge commit that restarts the in-flight CI cycle.
2. **(b) Project-bot deference** — `phase15-conventions.sh` now emits a `Project BEHIND handling: yes|no` trailer (above `Merge mechanism:`), set to `yes` when any workflow file contains an `update-branch` API call or a `mergeStateStatus`/`mergeable_state == BEHIND` probe. The outer monitor reads `MONITOR_PROJECT_HANDLES_BEHIND` at startup and skips the BEHIND branch entirely when set, deferring catch-up to the project-side merge-bot. All other events (`MERGED`, `CONFLICT`, `CI_FAILURE`, `NEW_COMMENT`, `STALLED_GREEN`) still emit.
3. **(c) Session-wide concurrency cap** — the outer monitor's BEHIND branch now wraps the helper invocation in `flock -n 9 ... 9>"$HOME/.claude/state/workflow-implement/<session-id>.behind-resolve.lock"` so only one PR's auto-resolve can be in flight across the orchestrator's monitored set. Lockfile path uses the new `MONITOR_SESSION_ID` env var (`wfi-...` ID); on contention, the monitor backs off silently to the next tick rather than emitting a digest line.

## Decisions made

- **(a) helper queries `gh pr view` itself** rather than accepting the rollup as a 5th positional argument. The duplicate query costs ~one extra `gh` call per BEHIND tick (rare in practice), keeps the helper signature stable, and avoids tangling the helper's contract with the outer monitor's JSON shape.
- **(b) detection heuristic is deliberately broad.** Two signals: literal `update-branch` substring (canonical merge-bot pattern, robust across `gh api`/`curl`/Octokit invocations), or `mergeStateStatus`/`mergeable_state` *and* `BEHIND`/`behind` co-occurring in the same workflow (catches workflows that branch on the state without invoking `update-branch`). Under-detection (skipping a project-side handler and racing it from the monitor) is the expensive failure mode this trailer is meant to prevent, so the bias is toward false-positives, which only cost a deferred BEHIND auto-resolve.
- **(c) silent next-tick backoff on lock contention** — the orchestrator's regular progress digest already surfaces BEHIND, so emitting an extra digest line on contention would be noise. The monitor naturally re-attempts on the next poll.
- **Trailer phrasing**: `Project BEHIND handling: yes` / `Project BEHIND handling: no` (the AC's exact phrasing, not the body's other variant).
- Lockfile lifetime: per-attempt; auto-released when the subshell carrying `flock` exits. The lockfile itself persists across runs (no cleanup needed; `flock` only cares about open file descriptors, not file presence).

## Test plan

- [ ] `bash plugins/workflow/skills/implement/scripts/tests/test-monitor-behind-resolve.sh` passes (5 new CI-precheck assertions covering pending / failure / mixed-success / empty rollup / transient gh failure).
- [ ] `bash plugins/workflow/skills/implement/scripts/tests/test-phase15-conventions.sh` passes (4 new BEHIND-handler-detection assertions against new fixtures + a label-bot-fixture-without-BEHIND-handling negative).
- [ ] `bash -n` syntax-check on `monitor-behind-resolve.sh`, `phase15-conventions.sh`, and the inline shell-monitor recipe extracted from `SKILL.md`.
- [ ] `flock -n` cross-process semantics smoke-tested locally (concurrent `monitor-pr.sh` instances correctly contend on the session lockfile).

Closes #100