### PR TITLE
feat(workflow): detect overlapping sessions, flag stale state

### DIFF
--- a/plugins/workflow/skills/implement/SKILL.md
+++ b/plugins/workflow/skills/implement/SKILL.md
@@ -22,7 +22,7 @@ The skill is self-contained: every dispatched agent receives the full work pipel
 | `/workflow:implement` | Default: equivalent to `--label scheduled`. |
 | `/workflow:implement --resume <id>` | Reattach to a prior session. Restores selector, resolved issue list, dep graph, and per-issue terminal state from `~/.claude/state/workflow-implement/<id>.json`, then re-enters Phase 5. |
 | `/workflow:implement --session list` | List resumable sessions in the per-user state directory: ID, repo, last-modified timestamp, selector summary, in-flight issue count. The orchestrator follows up with the `find-stale` probe so any session whose every active issue is CLOSED on GitHub is annotated `(stale — every active issue is CLOSED)` alongside a copy-pasteable `delete` invocation. |
-| `/workflow:implement <selector> --force` | Suppress the Phase 1.1 overlap-prompt — proceed even if another active session claims an overlapping issue. Equivalent to selecting `continue` at the interactive prompt. Use only after an eyes-on `--session list` review. |
+| `/workflow:implement <selector> --force` | Suppress the Phase 1.1 overlap-prompt — proceed even if another active session claims an overlapping issue. Equivalent to selecting `continue` at the interactive prompt. Use only after an eyes-on `--session list` review. **Carve-out (AC #3 of #104):** even with `--force`, the orchestrator still surfaces a one-line force-confirm prompt when an overlapping issue carries a Phase 2 clarification recorded by the peer session — the user is presumed to have forgotten the peer was running, and silently overriding a recorded clarification is the architecturally-divergent merge this guard exists to prevent. |
 
 Selectors compose: `/workflow:implement --milestone "MS-2 General" --label scheduled` intersects them. **`--resume` does not compose with selectors** — the resumed state file already encodes the original selector, so passing both is a hard error. Pass `--resume <id>` alone.
 
@@ -32,7 +32,7 @@ Every `/workflow:implement` invocation owns a **session ID** of the form `wfi-YY
 
 This is a different surface from **Phase 5 step 0 (per-issue resumption)**: that step recovers the *agent layer* (an in-flight branch / open PR) on a per-issue basis whenever it sees one. `--resume` rehydrates the *orchestrator layer* (selector, dep graph, task list, digest history) before Phase 5 runs at all. The two compose: `--resume` rehydrates orchestrator state, then Phase 5 step 0 still runs per-issue inside the rehydrated session and continues to discourage agent-level restart. See **§ Session state** below for the file shape and **§ Bail-outs** for the missing-state-file behaviour.
 
-**Concurrency guard at intake (#104).** When a fresh `/workflow:implement` invocation resolves its issue list at Phase 1.1, the orchestrator scans every state file under `~/.claude/state/workflow-implement/` for sessions in the same repo whose active issue numbers (state ∈ `scheduled` | `in-progress` | `automerge_set`) intersect the resolved list. Overlap is surfaced as a Phase-2-style batched message — the user picks `continue`, `skip <issue#>`, or bails to `--resume` the other session. Default behaviour on overlap is to bail; `--force` skips the interactive ask and proceeds. The same intake pass also runs a stale-session probe that flags sessions whose every active issue is CLOSED on GitHub (a dead session left behind by a Claude Code crash / host disconnect) and offers them up for `bash session-state.sh delete <id>` — they are not counted as active overlap and never auto-deleted. See **§ Phase 1.0 — Session ID** and **§ Phase 1.1 — Resolve the issue list** for the exact wiring.
+**Concurrency guard at intake (#104).** When a fresh `/workflow:implement` invocation resolves its issue list at Phase 1.1, the orchestrator first runs a stale-session probe (every active issue CLOSED on GitHub → dead session left behind by a Claude Code crash / host disconnect, surfaced for cleanup but not counted as overlap), then scans every other state file in the same repo for sessions whose active issue numbers (state ∈ `scheduled` | `in-progress` | `automerge_set`) intersect the resolved list. Overlap is surfaced as a Phase-2-style batched message — the user picks `continue`, `skip <issue#>`, or bails to `--resume` the other session. Default behaviour on overlap is to bail; `--force` skips the interactive ask and proceeds — **except** that when an overlapping issue carries a Phase 2 clarification recorded by the peer session, even `--force` still surfaces a one-line force-confirm prompt (AC #3 — the architecturally-divergent merge described in the issue is exactly the failure mode that carve-out prevents). Stale sessions are offered up for `bash session-state.sh delete <id>` and never auto-deleted. See **§ Phase 1.0 — Session ID** and **§ Phase 1.1 — Resolve the issue list** for the exact wiring.
 
 ## Operating principles
 
@@ -194,20 +194,63 @@ Exclude any issue that is closed, has the `released` label, or is currently labe
 
 #### Concurrency guard
 
-After resolving the issue list and applying the exclusion rules above, run the overlap scan **before** the Phase 4 label / TaskList writes. Two `/workflow:implement` invocations running against the same repo can otherwise silently race the same issue — the architecturally-divergent merge described in #104 (one session merged a different design than the user clarified with the other) is the failure mode this guard prevents.
+After resolving the issue list and applying the exclusion rules above, run the intake guard **before** the Phase 4 label / TaskList writes. Two `/workflow:implement` invocations running against the same repo can otherwise silently race the same issue — the architecturally-divergent merge described in #104 (one session merged a different design than the user clarified with the other) is the failure mode this guard prevents.
+
+The guard runs **the stale probe first, then the overlap probe**. The ordering is load-bearing: AC #4 of #104 is explicit that stale sessions are NOT counted as active overlap, and a state file whose every active issue is now CLOSED on GitHub would otherwise surface as a concurrency conflict — a false positive (the session is dead, not racing). Run `find-stale` first, collect the stale session IDs, then pass each one to `find-overlap --except <id>` so the overlap surface excludes them up front.
+
+Both probes need a `gh_state` mapping `{"<n>": "OPEN"|"CLOSED"}` covering every active issue across every peer state file in this repo — `find-stale` is offline-by-default and the orchestrator owns the network calls. Build it once:
 
 ```bash
-# Resolved in-scope issues from the steps above, as a JSON array. The
-# orchestrator already has them as JSON because the gh-CLI calls return
-# JSON; no string-munging needed.
+sshelp="$CLAUDE_PLUGIN_ROOT/skills/implement/scripts/session-state.sh"
+
+# Collect the active issue numbers across every state file scoped to
+# this repo. `list` is offline-by-default, so re-read each state file
+# with `get` and pull the active-state issue keys via jq.
+active_issues=$(bash "$sshelp" list \
+                | awk -F'\t' -v r="$repo" '$2 == r {print $1}' \
+                | while read -r id; do
+                    bash "$sshelp" get "$id" \
+                    | jq -r '.issues
+                             | with_entries(select(.value.state
+                                                   | IN("scheduled",
+                                                        "in-progress",
+                                                        "automerge_set")))
+                             | keys[]'
+                  done \
+                | sort -u)
+
+# Ask GitHub for the OPEN/CLOSED state of each one.
+gh_state=$(printf '%s\n' "$active_issues" \
+           | while read -r n; do
+               [[ -z "$n" ]] && continue
+               s=$(gh issue view "$n" --repo "$repo" --json state --jq .state)
+               printf '%s %s\n' "$n" "$s"
+             done \
+           | jq -nR '[inputs | split(" ") | {(.[0]): .[1]}] | add // {}')
+```
+
+Then run the two probes:
+
+```bash
+# Resolved in-scope issues from the steps above, as a JSON array.
 issues_json='[456,457,458]'   # example
 repo='aidanns/agent-auth'
 
-overlap=$(bash "$CLAUDE_PLUGIN_ROOT/skills/implement/scripts/session-state.sh" \
-            find-overlap "$repo" "$issues_json")
+# 1. Stale probe — collects every dead session in this repo. Use the
+#    result both to suppress false positives in (2) and to surface a
+#    cleanup prompt later (§ Stale-session probe).
+stale=$(bash "$sshelp" find-stale "$repo" - <<<"$gh_state")
+mapfile -t stale_except_args < <(jq -r '.[] | "--except\n" + .session_id' <<<"$stale")
+
+# 2. Overlap probe — peers with active claims on the resolved list,
+#    minus any stale peers from step 1 plus the orchestrator's own
+#    session ID.
+overlap=$(bash "$sshelp" find-overlap "$repo" "$issues_json" \
+                --except "$session_id" \
+                "${stale_except_args[@]}")
 ```
 
-`find-overlap` emits a JSON array of `{session_id, repo, updated_at, overlapping_issues:[<n>...]}` tuples — one per active peer session that intersects the input. Empty array → proceed silently. Non-empty → at least one peer session has an active claim. "Active" means `state ∈ {scheduled, in-progress, automerge_set}`: a peer that is `blocked` / `paused` does not hold an active dispatch (the issue can be picked up safely; the resumed session would notice on its next loop tick), and `merged` / `errored` / `externally_closed` are terminal.
+`find-overlap` emits a JSON array of `{session_id, repo, updated_at, overlapping_issues:[<n>...]}` tuples — one per active peer session that intersects the input. Empty array → proceed silently. Non-empty → at least one peer session has an active claim. "Active" means `state ∈ {scheduled, in-progress, automerge_set}`: a peer that is `blocked` / `paused` does not hold an active dispatch (the issue can be picked up safely; the resumed session would notice on its next loop tick), and `merged` / `errored` / `externally_closed` are terminal. `--except` is repeatable; pass every stale session ID alongside the orchestrator's own session ID to keep dead state files out of the overlap surface.
 
 ##### Surface overlap to the user (Phase-2-style batched message)
 
@@ -244,49 +287,31 @@ Wait for the user's answer. The orchestrator routes the answer:
 - **`hand off`** — abort this run with a Bail-out (see § Bail-outs). Surface the resume command for each peer session.
 - **`skip <issue#>`** — drop the named issues from the resolved list and re-run the overlap scan. Continue if the new list is empty of overlap; re-prompt if the user picked the same answer that left overlap.
 
-If the invocation carried `--force`, skip the prompt entirely — log a one-line audit notice (`overlap detected, --force → proceeding (peer sessions: <ids>)`) and proceed. `--force` is the explicit "I have already checked `--session list` and know what I'm doing" escape hatch — typically used when a prior session crashed without cleanup and the user is resuming the same logical work.
+If the invocation carried `--force`, skip the full bail prompt — but **still surface a one-line force-confirm** when an overlapping issue carries a Phase 2 clarification recorded by the peer session. AC #3 of #104 is explicit that the orchestrator should not silently proceed when the peer has clarifications baked into an overlapping issue body, *even if the user passed `--force`* — the user is presumed to have forgotten the peer session was running, and the architecturally-divergent merge described in the issue is precisely the failure mode this case prevents.
+
+Detection. For each peer session in the `overlap` array, read its `body_snapshot` field (per-issue, populated at the BLOCKED transition — see § Session state § Per-issue dispatch-context fields) for each overlapping issue. If the field is non-null on any overlapping issue, that peer has a Phase 2 clarification recorded for the issue. (`body_snapshot` is the orchestrator's most reliable signal that "this issue's body was changed by Phase 2 / a `Claude: Blocked — <q>` answer cycle"; it's the same field the parked-issue poll uses to detect out-of-band edits.) For peer sessions without a populated `body_snapshot`, the implementing agent is mid-flight and the user clarified at intake — the issue body was edited then, and the peer's `created_at` is the lower bound; cross-check `gh issue view <n> --json body,updatedAt` against that timestamp as a fallback.
+
+Force-confirm prompt:
+
+```text
+Concurrency override — --force was passed, but the peer session(s) recorded Phase 2
+clarifications on overlapping issue bodies. Per #104 AC #3 the orchestrator does
+not silently proceed in this case even with --force — the architecturally-divergent
+merge described in the issue is exactly the failure mode this prompt prevents.
+
+Overlapping issues with peer-recorded Phase 2 clarifications:
+  • #458 — peer wfi-2026-05-01-cc40 — Strategy A vs Strategy C clarification on body
+
+Continue? (yes / no — default no)
+```
+
+`yes` → log the override, append a digest line, proceed. `no` → bail (same as `hand off` in the un-forced bail prompt). When `--force` is set AND no overlapping issue carries a peer-recorded Phase 2 clarification, skip the force-confirm prompt entirely — log a one-line audit notice (`overlap detected, --force → proceeding (peer sessions: <ids>)`) and proceed. `--force` is the explicit "I have already checked `--session list` and know what I'm doing" escape hatch — typically used when a prior session crashed without cleanup and the user is resuming the same logical work.
 
 ##### Stale-session probe (offered for cleanup, not auto-deleted)
 
-After the overlap prompt resolves (or when there was no overlap), run the stale-session probe so abandoned state files don't clutter `--session list` indefinitely:
-
-```bash
-sshelp="$CLAUDE_PLUGIN_ROOT/skills/implement/scripts/session-state.sh"
-
-# 1. Collect the active issue numbers across every state file scoped to
-#    this repo. `list` is offline-by-default, so we re-read each state
-#    file with `get` and pull the active-state issue keys via jq.
-active_issues=$(bash "$sshelp" list \
-                | awk -F'\t' -v r="$repo" '$2 == r {print $1}' \
-                | while read -r id; do
-                    bash "$sshelp" get "$id" \
-                    | jq -r '.issues
-                             | with_entries(select(.value.state
-                                                   | IN("scheduled",
-                                                        "in-progress",
-                                                        "automerge_set")))
-                             | keys[]'
-                  done \
-                | sort -u)
-
-# 2. Ask GitHub for the OPEN/CLOSED state of each one and assemble a
-#    JSON mapping `{"<n>": "OPEN"|"CLOSED"}`.
-gh_state=$(printf '%s\n' "$active_issues" \
-           | while read -r n; do
-               [[ -z "$n" ]] && continue
-               s=$(gh issue view "$n" --repo "$repo" --json state --jq .state)
-               printf '%s %s\n' "$n" "$s"
-             done \
-           | jq -nR '[inputs | split(" ") | {(.[0]): .[1]}] | add // {}')
-
-# 3. Hand the mapping to `find-stale` (offline-only — script makes no
-#    network calls).
-stale=$(bash "$sshelp" find-stale "$repo" - <<<"$gh_state")
-```
-
 `find-stale` emits the same `{session_id, repo, updated_at, active_issues:[<n>...]}` shape as `find-overlap`, restricted to sessions where every active issue is CLOSED on GitHub — a session that nominally still has dispatches in flight, but every dispatched issue has been closed (merged elsewhere, deleted as duplicate, hand-merged by the user) without the orchestrator updating the state file. That is a dead session.
 
-If the result is non-empty, surface to the user — but do **not** auto-delete (a state file deletion is irrecoverable, and a user who saw an issue close out-of-band may still want the digest history):
+The `stale` variable from step 1 of the worked example carries the result. After the overlap prompt resolves (or when there was no overlap), surface stale sessions to the user — but do **not** auto-delete (a state file deletion is irrecoverable, and a user who saw an issue close out-of-band may still want the digest history):
 
 ```text
 Stale sessions detected (every active issue is CLOSED on GitHub):

--- a/plugins/workflow/skills/implement/SKILL.md
+++ b/plugins/workflow/skills/implement/SKILL.md
@@ -21,7 +21,8 @@ The skill is self-contained: every dispatched agent receives the full work pipel
 | `/workflow:implement --parent <n>` | Process all sub-issues of the parent issue. |
 | `/workflow:implement` | Default: equivalent to `--label scheduled`. |
 | `/workflow:implement --resume <id>` | Reattach to a prior session. Restores selector, resolved issue list, dep graph, and per-issue terminal state from `~/.claude/state/workflow-implement/<id>.json`, then re-enters Phase 5. |
-| `/workflow:implement --session list` | List resumable sessions in the per-user state directory: ID, repo, last-modified timestamp, selector summary, in-flight issue count. |
+| `/workflow:implement --session list` | List resumable sessions in the per-user state directory: ID, repo, last-modified timestamp, selector summary, in-flight issue count. The orchestrator follows up with the `find-stale` probe so any session whose every active issue is CLOSED on GitHub is annotated `(stale — every active issue is CLOSED)` alongside a copy-pasteable `delete` invocation. |
+| `/workflow:implement <selector> --force` | Suppress the Phase 1.1 overlap-prompt — proceed even if another active session claims an overlapping issue. Equivalent to selecting `continue` at the interactive prompt. Use only after an eyes-on `--session list` review. |
 
 Selectors compose: `/workflow:implement --milestone "MS-2 General" --label scheduled` intersects them. **`--resume` does not compose with selectors** — the resumed state file already encodes the original selector, so passing both is a hard error. Pass `--resume <id>` alone.
 
@@ -31,7 +32,7 @@ Every `/workflow:implement` invocation owns a **session ID** of the form `wfi-YY
 
 This is a different surface from **Phase 5 step 0 (per-issue resumption)**: that step recovers the *agent layer* (an in-flight branch / open PR) on a per-issue basis whenever it sees one. `--resume` rehydrates the *orchestrator layer* (selector, dep graph, task list, digest history) before Phase 5 runs at all. The two compose: `--resume` rehydrates orchestrator state, then Phase 5 step 0 still runs per-issue inside the rehydrated session and continues to discourage agent-level restart. See **§ Session state** below for the file shape and **§ Bail-outs** for the missing-state-file behaviour.
 
-> **Out of scope (future):** a concurrency guard that detects when two `/workflow:implement` invocations claim overlapping issues. With distinct session IDs it would be cheap to add — each session's state file lists its in-flight issue numbers — but it isn't implemented yet. A second invocation against an overlapping selector will silently race; the user is responsible for not starting one.
+**Concurrency guard at intake (#104).** When a fresh `/workflow:implement` invocation resolves its issue list at Phase 1.1, the orchestrator scans every state file under `~/.claude/state/workflow-implement/` for sessions in the same repo whose active issue numbers (state ∈ `scheduled` | `in-progress` | `automerge_set`) intersect the resolved list. Overlap is surfaced as a Phase-2-style batched message — the user picks `continue`, `skip <issue#>`, or bails to `--resume` the other session. Default behaviour on overlap is to bail; `--force` skips the interactive ask and proceeds. The same intake pass also runs a stale-session probe that flags sessions whose every active issue is CLOSED on GitHub (a dead session left behind by a Claude Code crash / host disconnect) and offers them up for `bash session-state.sh delete <id>` — they are not counted as active overlap and never auto-deleted. See **§ Phase 1.0 — Session ID** and **§ Phase 1.1 — Resolve the issue list** for the exact wiring.
 
 ## Operating principles
 
@@ -191,6 +192,111 @@ gh api "repos/:owner/:repo/issues/<n>/sub_issues" --jq '.[].number'
 
 Exclude any issue that is closed, has the `released` label, or is currently labelled `in-progress` by a different active session (check the comment trail to disambiguate). Surface a one-line note for each excluded issue.
 
+#### Concurrency guard
+
+After resolving the issue list and applying the exclusion rules above, run the overlap scan **before** the Phase 4 label / TaskList writes. Two `/workflow:implement` invocations running against the same repo can otherwise silently race the same issue — the architecturally-divergent merge described in #104 (one session merged a different design than the user clarified with the other) is the failure mode this guard prevents.
+
+```bash
+# Resolved in-scope issues from the steps above, as a JSON array. The
+# orchestrator already has them as JSON because the gh-CLI calls return
+# JSON; no string-munging needed.
+issues_json='[456,457,458]'   # example
+repo='aidanns/agent-auth'
+
+overlap=$(bash "$CLAUDE_PLUGIN_ROOT/skills/implement/scripts/session-state.sh" \
+            find-overlap "$repo" "$issues_json")
+```
+
+`find-overlap` emits a JSON array of `{session_id, repo, updated_at, overlapping_issues:[<n>...]}` tuples — one per active peer session that intersects the input. Empty array → proceed silently. Non-empty → at least one peer session has an active claim. "Active" means `state ∈ {scheduled, in-progress, automerge_set}`: a peer that is `blocked` / `paused` does not hold an active dispatch (the issue can be picked up safely; the resumed session would notice on its next loop tick), and `merged` / `errored` / `externally_closed` are terminal.
+
+##### Surface overlap to the user (Phase-2-style batched message)
+
+When the array is non-empty, surface it to the user with the same single-batched-message UX Phase 2 uses for clarifications. The default action is **bail** unless the user explicitly confirms or `--force` was passed on the invocation:
+
+```text
+Concurrency conflict — another /workflow:implement session is already claiming an
+issue this run is about to take. The 2026-05-01 reproduction (cc40 vs the unnamed
+sibling on aidanns/agent-auth #458) is exactly the failure mode this guard prevents:
+two sessions racing the same issue, the second one merging an architecturally-
+divergent design while the first is still working.
+
+Overlap detected:
+  1. wfi-2026-05-01-cc40 — repo=aidanns/agent-auth — updated 2026-05-01T12:05Z
+       overlapping issues: #458
+  2. wfi-2026-05-01-aaaa — repo=aidanns/agent-auth — updated 2026-05-02T09:11Z
+       overlapping issues: #458
+
+Pick one:
+  • continue                        — proceed anyway (race the other session — only
+                                      do this if you are sure the other session has
+                                      ended and the state file just hasn't been
+                                      cleaned up). Equivalent to passing --force.
+  • hand off                        — bail this run; resume the other session
+                                      instead via /workflow:implement --resume <id>.
+  • skip <issue#> [<issue#> …]      — drop the named issues from this run's scope
+                                      and continue with the rest. The peer session
+                                      keeps them.
+```
+
+Wait for the user's answer. The orchestrator routes the answer:
+
+- **`continue`** — log the override, append a digest line via `append-digest` recording the overridden session IDs, and proceed to Phase 1.5. The peer session(s) will notice the contention on their next loop tick if the issue's labels diverge.
+- **`hand off`** — abort this run with a Bail-out (see § Bail-outs). Surface the resume command for each peer session.
+- **`skip <issue#>`** — drop the named issues from the resolved list and re-run the overlap scan. Continue if the new list is empty of overlap; re-prompt if the user picked the same answer that left overlap.
+
+If the invocation carried `--force`, skip the prompt entirely — log a one-line audit notice (`overlap detected, --force → proceeding (peer sessions: <ids>)`) and proceed. `--force` is the explicit "I have already checked `--session list` and know what I'm doing" escape hatch — typically used when a prior session crashed without cleanup and the user is resuming the same logical work.
+
+##### Stale-session probe (offered for cleanup, not auto-deleted)
+
+After the overlap prompt resolves (or when there was no overlap), run the stale-session probe so abandoned state files don't clutter `--session list` indefinitely:
+
+```bash
+sshelp="$CLAUDE_PLUGIN_ROOT/skills/implement/scripts/session-state.sh"
+
+# 1. Collect the active issue numbers across every state file scoped to
+#    this repo. `list` is offline-by-default, so we re-read each state
+#    file with `get` and pull the active-state issue keys via jq.
+active_issues=$(bash "$sshelp" list \
+                | awk -F'\t' -v r="$repo" '$2 == r {print $1}' \
+                | while read -r id; do
+                    bash "$sshelp" get "$id" \
+                    | jq -r '.issues
+                             | with_entries(select(.value.state
+                                                   | IN("scheduled",
+                                                        "in-progress",
+                                                        "automerge_set")))
+                             | keys[]'
+                  done \
+                | sort -u)
+
+# 2. Ask GitHub for the OPEN/CLOSED state of each one and assemble a
+#    JSON mapping `{"<n>": "OPEN"|"CLOSED"}`.
+gh_state=$(printf '%s\n' "$active_issues" \
+           | while read -r n; do
+               [[ -z "$n" ]] && continue
+               s=$(gh issue view "$n" --repo "$repo" --json state --jq .state)
+               printf '%s %s\n' "$n" "$s"
+             done \
+           | jq -nR '[inputs | split(" ") | {(.[0]): .[1]}] | add // {}')
+
+# 3. Hand the mapping to `find-stale` (offline-only — script makes no
+#    network calls).
+stale=$(bash "$sshelp" find-stale "$repo" - <<<"$gh_state")
+```
+
+`find-stale` emits the same `{session_id, repo, updated_at, active_issues:[<n>...]}` shape as `find-overlap`, restricted to sessions where every active issue is CLOSED on GitHub — a session that nominally still has dispatches in flight, but every dispatched issue has been closed (merged elsewhere, deleted as duplicate, hand-merged by the user) without the orchestrator updating the state file. That is a dead session.
+
+If the result is non-empty, surface to the user — but do **not** auto-delete (a state file deletion is irrecoverable, and a user who saw an issue close out-of-band may still want the digest history):
+
+```text
+Stale sessions detected (every active issue is CLOSED on GitHub):
+  • wfi-2026-04-30-deef — repo=aidanns/agent-auth — last update 2026-04-30T18:42Z
+      active issues: #401 #402 #403 — all CLOSED on GitHub
+      Delete? bash "$CLAUDE_PLUGIN_ROOT/skills/implement/scripts/session-state.sh" delete wfi-2026-04-30-deef
+```
+
+Continue with the run regardless of the user's response — stale-session cleanup is an out-of-band housekeeping prompt, not a gate on the new run. The user can copy-paste the suggested `delete` invocation now, later, or never.
+
 ### Auto-memory sweep for known-broken CI / manual workarounds
 
 Sweep `~/.claude/projects/<project-slug>/memory/` for entries matching `*_bot_secrets*`, `*_broken*`, `*_pending*`, or whose body contains `manual workaround` / `skip silently` / `secrets not configured`. Inject any matches into every dispatch prompt under a "Known-broken CI / manual workarounds in this project" section.
@@ -314,7 +420,9 @@ Subcommands:
 | `add-worktree <id> <issue#> <path>` | Phase 5 / Phase 5b → append `<path>` to `issues[<issue#>].worktrees`. Idempotent — re-adding a path the array already contains is a no-op. The orchestrator calls this immediately after parsing each `isolation: worktree`-dispatched agent's terminal notification, so Phase 6 housekeeping can iterate every worktree spawned during the PR's lifecycle. |
 | `append-digest <id> <line>` | Phase 5 progress reporting → append a digest line to `digest_tail` (capped at 50 entries). |
 | `list` | `--session list` → enumerate every state file with ID, repo, last-modified timestamp, selector summary, in-flight count. |
-| `delete <id>` | Phase 8 → remove the state file once every issue is terminal. |
+| `find-overlap <repo> <issues-json> [--except <id>]` | Phase 1.1 → emit a JSON array of peer sessions whose active issues (state ∈ `scheduled`/`in-progress`/`automerge_set`) intersect the input issue list, scoped to `<repo>`. `--except <id>` skips the named session (the caller's own state file when the scan runs after `init`). Returns `[]` when no overlap is found. |
+| `find-stale [<repo>] <gh-state-json>` | Phase 1.1 → emit a JSON array of sessions whose every active issue is CLOSED on GitHub per the supplied mapping (`{"<n>": "OPEN"|"CLOSED"}`). Mapping is read from a file path or `-` for stdin so the script stays offline-by-default; the orchestrator owns the `gh issue view` calls. |
+| `delete <id>` | Phase 8 → remove the state file once every issue is terminal. Also offered to the user by the Phase 1.1 stale-session probe. |
 
 The script keeps all JSON manipulation inside `jq`; the orchestrator should not parse / format the JSON itself.
 
@@ -1620,6 +1728,7 @@ The skill stops the run rather than parking when:
 - **`--resume <id>` was passed but `~/.claude/state/workflow-implement/<id>.json` does not exist.** Do not auto-create — surface the error verbatim ("session state not found: <id>") and exit. The user typically wants to either (a) check for typos in the ID, (b) run `--session list` to see what is actually resumable, or (c) start a fresh run instead.
 - **`--resume <id>` was passed and the state file exists but is unparseable JSON** (truncated mid-write after a crash / disk-full / SIGKILL, partial schema, corrupted UTF-8). Surface the error verbatim ("session state corrupted: <path>") and point the user at **§ Session state § Recovering a corrupted state file** for the manual recovery sequence. Do not attempt to repair in-place — re-deriving from a half-written file is how silent state-divergence happens. The user explicitly chooses between "fix the JSON by hand" and "delete the file and lose dep graph / digest history."
 - **`--resume <id>` was combined with a selector flag** (`--label`, `--milestone`, `--parent`, or explicit issue numbers). The resumed state file already encodes the original selector; combining the two is ambiguous. Surface "--resume cannot be combined with selector flags" and exit.
+- **The Phase 1.1 overlap scan found a peer session and the user picked `hand off`** (or `--force` was *not* set and the user declined to confirm `continue`). Surface the peer session ID(s) plus the `/workflow:implement --resume <id>` invocation the user can run to continue the existing work, and exit. This is the default outcome when overlap is detected — the failure mode (#104) it prevents is two sessions silently racing the same issue and merging architecturally-divergent designs.
 
 In each case: leave labels as-is, surface immediately to user, do not proceed.
 

--- a/plugins/workflow/skills/implement/scripts/session-state.sh
+++ b/plugins/workflow/skills/implement/scripts/session-state.sh
@@ -57,6 +57,45 @@
 #       user sees there is a problem and can follow the manual recovery
 #       sequence in SKILL.md.
 #
+#   find-overlap <repo> <issues-json> [--except <session-id>]
+#       Scan every state file under the state directory, filter to sessions
+#       whose `repo` field matches <repo>, and intersect each session's
+#       active issue numbers (state ∈ scheduled | in-progress |
+#       automerge_set) against the input <issues-json> array. Emit a JSON
+#       array of overlapping tuples on stdout — one element per session
+#       with overlap, of shape `{session_id, repo, updated_at,
+#       overlapping_issues:[<n>...]}`. Sessions with no overlap are omitted.
+#       The optional `--except <session-id>` flag skips the named session
+#       (the caller's own state file, when the scan happens after `init`
+#       wrote it). Exits 0 with `[]` when no overlap is found — the orches-
+#       trator distinguishes "scan ran cleanly, no overlap" from "scan
+#       failed" by parsing the JSON, not by exit code.
+#
+#       The active-state set deliberately excludes `merged`, `blocked`,
+#       `paused`, `errored`, and `externally_closed`: a session that is
+#       parked on a clarification (`blocked`) or paused on a usage cap
+#       (`paused`) is still alive in the user's mental model, but neither
+#       holds an *active dispatch* on the issue — a fresh run claiming the
+#       same issue can pick it up safely (the resumed session would notice
+#       on its next loop tick that the label changed). Concretely: the
+#       overlap that matters is "two implementing agents racing the same
+#       PR", not "the same issue lives in two state files."
+#
+#   find-stale [<repo>] <gh-state-json>
+#       Determine which sessions are stale — every active issue (state ∈
+#       scheduled | in-progress | automerge_set) has GitHub-state CLOSED
+#       per the supplied <gh-state-json> mapping (`{"<issue#>": "OPEN" |
+#       "CLOSED"}`). The mapping is read from a path argument or `-` for
+#       stdin; the orchestrator owns the `gh issue view` calls that
+#       populate it (this script stays offline-by-default — no network).
+#       Optional <repo> filters the scan to that `<owner>/<repo>` only.
+#       Emits a JSON array of `{session_id, repo, updated_at,
+#       active_issues:[<n>...]}` tuples on stdout — one element per stale
+#       session. Sessions with at least one OPEN active issue, or with no
+#       active issues at all (every issue terminal — Phase 8 GC will
+#       handle them), are omitted. Exits 0 with `[]` when no stale
+#       sessions are found.
+#
 #   delete <id>
 #       Remove the state file. No-op if it doesn't exist (the all-terminal
 #       garbage-collection path in Phase 8 calls this; idempotency keeps
@@ -85,6 +124,8 @@ Usage:
   session-state.sh add-worktree <id> <issue#> <path>
   session-state.sh append-digest <id> <digest-line>
   session-state.sh list
+  session-state.sh find-overlap <repo> <issues-json> [--except <session-id>]
+  session-state.sh find-stale [<repo>] <gh-state-json-path-or-->
   session-state.sh delete <id>
 EOF
   exit 2
@@ -328,6 +369,147 @@ cmd_list() {
   done
 }
 
+# Read every parseable state file into a single JSON array on stdout.
+# Unparseable files are silently skipped: `cmd_list` is the surface that
+# flags corruption to the user, and we do not want a corrupted neighbour
+# session to block a fresh intake's overlap or stale scan. Returns `[]`
+# when the state directory does not exist.
+read_all_sessions() {
+  if [[ ! -d "$state_dir" ]]; then
+    printf '[]\n'
+    return 0
+  fi
+  local f parseable=()
+  for f in "$state_dir"/*.json; do
+    [[ -f "$f" ]] || continue
+    if jq -e . "$f" >/dev/null 2>&1; then
+      parseable+=("$f")
+    fi
+  done
+  if (( ${#parseable[@]} == 0 )); then
+    printf '[]\n'
+    return 0
+  fi
+  jq -s -c . "${parseable[@]}"
+}
+
+cmd_find_overlap() {
+  local repo="${1:?repo required}"
+  local issues_json="${2:?issues-json required}"
+  shift 2
+
+  # Optional `--except <session-id>` lets the caller skip its own state
+  # file. The most common case is the orchestrator scanning after Phase 3
+  # has written the new session's state — the new session would otherwise
+  # appear in its own overlap output.
+  local except=""
+  while (( $# > 0 )); do
+    case "$1" in
+      --except)
+        except="${2:?--except requires a session-id}"
+        shift 2
+        ;;
+      *)
+        printf 'session-state: find-overlap: unexpected argument %q\n' "$1" >&2
+        exit 2
+        ;;
+    esac
+  done
+
+  # Validate the issues-json input — bail with exit 2 on malformed input
+  # rather than silently treating bad input as "no overlap" (which would
+  # bypass the guard at intake exactly when it matters most).
+  if ! jq -e 'type == "array" and all(.[]; type == "number")' >/dev/null 2>&1 <<<"$issues_json"; then
+    printf 'session-state: find-overlap: <issues-json> must be a JSON array of numbers\n' >&2
+    exit 2
+  fi
+
+  read_all_sessions | jq -c \
+    --arg repo "$repo" \
+    --argjson input "$issues_json" \
+    --arg except "$except" \
+    '
+    map(select(.repo == $repo and (.session_id != $except)))
+    | map(
+        . as $sess
+        | ($input
+           | map(tostring)
+           | map(select(
+               ($sess.issues[.] // {}) as $rec
+               | ($rec.state // "") | IN("scheduled", "in-progress", "automerge_set")
+             ))
+           | map(tonumber)
+          ) as $overlap
+        | select($overlap | length > 0)
+        | {
+            session_id: $sess.session_id,
+            repo: $sess.repo,
+            updated_at: $sess.updated_at,
+            overlapping_issues: $overlap
+          }
+      )
+    '
+}
+
+cmd_find_stale() {
+  # Either `find-stale <repo> <gh-state-json>` or `find-stale <gh-state-json>`.
+  # The repo argument is optional and acts as a filter; absent, every
+  # session is considered. The gh-state-json argument is required — pass
+  # `-` to read from stdin or a path to read from disk.
+  if (( $# < 1 )); then
+    printf 'session-state: find-stale: <gh-state-json> required\n' >&2
+    exit 2
+  fi
+
+  local repo="" gh_state_src
+  if (( $# == 1 )); then
+    gh_state_src="$1"
+  else
+    repo="$1"
+    gh_state_src="$2"
+  fi
+
+  local gh_state_json
+  if [[ "$gh_state_src" == "-" ]]; then
+    gh_state_json=$(cat)
+  else
+    if [[ ! -f "$gh_state_src" ]]; then
+      printf 'session-state: find-stale: gh-state file not found: %s\n' "$gh_state_src" >&2
+      exit 2
+    fi
+    gh_state_json=$(cat "$gh_state_src")
+  fi
+
+  if ! jq -e 'type == "object" and all(.[]; type == "string")' >/dev/null 2>&1 <<<"$gh_state_json"; then
+    printf 'session-state: find-stale: <gh-state-json> must be a JSON object {"<n>": "OPEN"|"CLOSED"}\n' >&2
+    exit 2
+  fi
+
+  read_all_sessions | jq -c \
+    --arg repo "$repo" \
+    --argjson gh "$gh_state_json" \
+    '
+    map(select($repo == "" or .repo == $repo))
+    | map(
+        . as $sess
+        | ([$sess.issues[]
+            | select(.state | IN("scheduled", "in-progress", "automerge_set"))
+            | .number]
+          ) as $active
+        | select(($active | length) > 0)
+        | select($active
+                 | all(. as $n
+                       | ($gh[$n | tostring] // "OPEN") == "CLOSED"))
+        | {
+            session_id: $sess.session_id,
+            repo: $sess.repo,
+            updated_at: $sess.updated_at,
+            active_issues: $active
+          }
+      )
+    '
+}
+
 cmd_delete() {
   local id="${1:?id required}"
   local path
@@ -347,6 +529,8 @@ main() {
     add-worktree)   cmd_add_worktree "$@" ;;
     append-digest)  cmd_append_digest "$@" ;;
     list)           cmd_list "$@" ;;
+    find-overlap)   cmd_find_overlap "$@" ;;
+    find-stale)     cmd_find_stale "$@" ;;
     delete)         cmd_delete "$@" ;;
     -h|--help|help) usage ;;
     *)              usage ;;

--- a/plugins/workflow/skills/implement/scripts/session-state.sh
+++ b/plugins/workflow/skills/implement/scripts/session-state.sh
@@ -57,7 +57,7 @@
 #       user sees there is a problem and can follow the manual recovery
 #       sequence in SKILL.md.
 #
-#   find-overlap <repo> <issues-json> [--except <session-id>]
+#   find-overlap <repo> <issues-json> [--except <session-id>]...
 #       Scan every state file under the state directory, filter to sessions
 #       whose `repo` field matches <repo>, and intersect each session's
 #       active issue numbers (state ∈ scheduled | in-progress |
@@ -65,11 +65,13 @@
 #       array of overlapping tuples on stdout — one element per session
 #       with overlap, of shape `{session_id, repo, updated_at,
 #       overlapping_issues:[<n>...]}`. Sessions with no overlap are omitted.
-#       The optional `--except <session-id>` flag skips the named session
-#       (the caller's own state file, when the scan happens after `init`
-#       wrote it). Exits 0 with `[]` when no overlap is found — the orches-
-#       trator distinguishes "scan ran cleanly, no overlap" from "scan
-#       failed" by parsing the JSON, not by exit code.
+#       `--except <session-id>` (repeatable) skips named sessions; the
+#       orchestrator passes its own session ID and every session ID
+#       returned by `find-stale` so dead sessions don't surface as
+#       concurrency conflicts (AC #4 of #104). Exits 0 with `[]` when no
+#       overlap is found — the orchestrator distinguishes "scan ran
+#       cleanly, no overlap" from "scan failed" by parsing the JSON, not
+#       by exit code.
 #
 #       The active-state set deliberately excludes `merged`, `blocked`,
 #       `paused`, `errored`, and `externally_closed`: a session that is
@@ -124,7 +126,7 @@ Usage:
   session-state.sh add-worktree <id> <issue#> <path>
   session-state.sh append-digest <id> <digest-line>
   session-state.sh list
-  session-state.sh find-overlap <repo> <issues-json> [--except <session-id>]
+  session-state.sh find-overlap <repo> <issues-json> [--except <session-id>]...
   session-state.sh find-stale [<repo>] <gh-state-json-path-or-->
   session-state.sh delete <id>
 EOF
@@ -398,15 +400,28 @@ cmd_find_overlap() {
   local issues_json="${2:?issues-json required}"
   shift 2
 
-  # Optional `--except <session-id>` lets the caller skip its own state
-  # file. The most common case is the orchestrator scanning after Phase 3
-  # has written the new session's state — the new session would otherwise
-  # appear in its own overlap output.
-  local except=""
+  # Optional `--except <session-id>` (repeatable) lets the caller skip
+  # specific peer sessions from the overlap result. Two distinct callers:
+  #
+  #   1. The caller's own state file. The orchestrator scanning after
+  #      Phase 3 has written the new session's state would otherwise see
+  #      itself in the output.
+  #
+  #   2. Stale sessions identified by `find-stale`. AC #4 of #104 is
+  #      explicit that stale sessions are NOT counted as active overlap
+  #      — they are surfaced separately and offered for cleanup. The
+  #      orchestrator runs `find-stale` first, then passes each stale
+  #      session ID as `--except <id>` so a dead state file does not
+  #      generate a false-positive concurrency-conflict prompt.
+  local except_json='[]'
   while (( $# > 0 )); do
     case "$1" in
       --except)
-        except="${2:?--except requires a session-id}"
+        local v="${2:?--except requires a session-id}"
+        except_json=$(jq -nc \
+          --argjson acc "$except_json" \
+          --arg id "$v" \
+          '$acc + [$id]')
         shift 2
         ;;
       *)
@@ -427,9 +442,9 @@ cmd_find_overlap() {
   read_all_sessions | jq -c \
     --arg repo "$repo" \
     --argjson input "$issues_json" \
-    --arg except "$except" \
+    --argjson except "$except_json" \
     '
-    map(select(.repo == $repo and (.session_id != $except)))
+    map(select(.repo == $repo and (.session_id | IN($except[]) | not)))
     | map(
         . as $sess
         | ($input

--- a/plugins/workflow/skills/implement/scripts/tests/test-session-state.sh
+++ b/plugins/workflow/skills/implement/scripts/tests/test-session-state.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 
-# Regression tests for `session-state.sh`. Focused on the `add-worktree`
-# subcommand introduced for issue #102 (every dispatched-agent worktree
-# must be tracked so Phase 6 housekeeping can remove all of them, not
-# just the implementing agent's). Also exercises the surrounding
-# invariants the new field interacts with: `init` seeds `worktrees: []`
-# per issue, `update-issue worktree=<p>` does not disturb the plural
-# array, and idempotent re-appends do not duplicate paths.
+# Regression tests for `session-state.sh`. Originally focused on the
+# `add-worktree` subcommand from #102; extended in #104 to cover the
+# `find-overlap` and `find-stale` subcommands the orchestrator calls at
+# intake (Phase 1.0 / 1.1) to detect a second `/workflow:implement`
+# invocation racing the same issue or a state file abandoned by a dead
+# session. The surrounding `add-worktree` invariants are still exercised:
+# `init` seeds `worktrees: []` per issue, `update-issue worktree=<p>`
+# does not disturb the plural array, and idempotent re-appends do not
+# duplicate paths.
 #
 # Each test runs against an isolated state directory via the
 # `WORKFLOW_IMPLEMENT_STATE_DIR` env override the script already
@@ -187,6 +189,232 @@ bash "$script" add-worktree wfi-test-9 281 /tmp/worktrees/agent-b
 paths=$(bash "$script" get wfi-test-9 | jq -r '.issues["281"].worktrees[]' | tr '\n' ',' )
 assert_eq "get + jq iterates the worktrees array" \
   "/tmp/worktrees/agent-a,/tmp/worktrees/agent-b," "$paths"
+
+# --- find-overlap ----------------------------------------------------
+# The intake-time scan a `/workflow:implement` invocation runs to detect
+# another session already claiming an issue this one is about to claim.
+# The active state set is `scheduled | in-progress | automerge_set`;
+# `merged`, `blocked`, `paused`, `errored`, `externally_closed` are NOT
+# active overlap (a parked issue can be picked up by a fresh run; an
+# already-merged one is gone from the work pool entirely).
+
+# --- Test 10: find-overlap on an empty state directory returns []. ----
+sandbox=$(with_sandbox); cleanup_dirs+=("$sandbox")
+export WORKFLOW_IMPLEMENT_STATE_DIR="$sandbox"
+got=$(bash "$script" find-overlap acme/repo '[1,2,3]' | jq -c '.')
+assert_eq "find-overlap on empty state dir returns []" '[]' "$got"
+
+# --- Test 11: find-overlap finds a single-issue overlap. --------------
+sandbox=$(with_sandbox); cleanup_dirs+=("$sandbox")
+export WORKFLOW_IMPLEMENT_STATE_DIR="$sandbox"
+run_init wfi-overlap-a acme/repo '[456,457,458]'
+got=$(bash "$script" find-overlap acme/repo '[458]' \
+      | jq -c 'map({session_id, overlapping_issues})')
+assert_eq "find-overlap surfaces session and the overlapping issue" \
+  '[{"session_id":"wfi-overlap-a","overlapping_issues":[458]}]' \
+  "$got"
+
+# --- Test 12: find-overlap finds multi-issue overlap. -----------------
+sandbox=$(with_sandbox); cleanup_dirs+=("$sandbox")
+export WORKFLOW_IMPLEMENT_STATE_DIR="$sandbox"
+run_init wfi-overlap-multi acme/repo '[456,457,458]'
+got=$(bash "$script" find-overlap acme/repo '[456,458,500]' \
+      | jq -c 'map({session_id, overlapping_issues})')
+assert_eq "find-overlap returns every overlapping issue, in input order" \
+  '[{"session_id":"wfi-overlap-multi","overlapping_issues":[456,458]}]' \
+  "$got"
+
+# --- Test 13: find-overlap returns an empty array on no overlap. ------
+sandbox=$(with_sandbox); cleanup_dirs+=("$sandbox")
+export WORKFLOW_IMPLEMENT_STATE_DIR="$sandbox"
+run_init wfi-no-overlap acme/repo '[100,101]'
+got=$(bash "$script" find-overlap acme/repo '[200,201]' | jq -c '.')
+assert_eq "find-overlap returns [] when issues do not intersect" '[]' "$got"
+
+# --- Test 14: find-overlap filters by repo. ---------------------------
+# A session claiming the same issue *number* in a different repo is not
+# overlap — the issue numbers are scoped to the repo.
+sandbox=$(with_sandbox); cleanup_dirs+=("$sandbox")
+export WORKFLOW_IMPLEMENT_STATE_DIR="$sandbox"
+run_init wfi-other-repo other/repo '[458]'
+got=$(bash "$script" find-overlap acme/repo '[458]' | jq -c '.')
+assert_eq "find-overlap scopes overlap to the requested repo" '[]' "$got"
+
+# --- Test 15: find-overlap honours --except <session-id>. -------------
+# The orchestrator scans after Phase 3 has written its own state file;
+# without --except it would see itself in the overlap output.
+sandbox=$(with_sandbox); cleanup_dirs+=("$sandbox")
+export WORKFLOW_IMPLEMENT_STATE_DIR="$sandbox"
+run_init wfi-self acme/repo '[458]'
+run_init wfi-other acme/repo '[458]'
+got=$(bash "$script" find-overlap acme/repo '[458]' --except wfi-self \
+      | jq -c '[.[] | .session_id]')
+assert_eq "find-overlap --except skips the named session" \
+  '["wfi-other"]' "$got"
+
+# --- Test 16: find-overlap excludes terminal / parked states. ---------
+# Active set = scheduled | in-progress | automerge_set. The other
+# possibilities (merged | blocked | paused | errored | externally_closed)
+# are either gone from the work pool or recoverable-by-the-other-session
+# without holding an active dispatch.
+sandbox=$(with_sandbox); cleanup_dirs+=("$sandbox")
+export WORKFLOW_IMPLEMENT_STATE_DIR="$sandbox"
+run_init wfi-mixed-states term/repo '[1,2,3,4,5,6,7,8]'
+bash "$script" update-issue wfi-mixed-states 1 scheduled        >/dev/null
+bash "$script" update-issue wfi-mixed-states 2 in-progress      >/dev/null
+bash "$script" update-issue wfi-mixed-states 3 automerge_set    >/dev/null
+bash "$script" update-issue wfi-mixed-states 4 merged           >/dev/null
+bash "$script" update-issue wfi-mixed-states 5 blocked          >/dev/null
+bash "$script" update-issue wfi-mixed-states 6 paused           >/dev/null
+bash "$script" update-issue wfi-mixed-states 7 errored          >/dev/null
+bash "$script" update-issue wfi-mixed-states 8 externally_closed >/dev/null
+got=$(bash "$script" find-overlap term/repo '[1,2,3,4,5,6,7,8]' \
+      | jq -c '.[] | .overlapping_issues')
+assert_eq "find-overlap only counts scheduled/in-progress/automerge_set" \
+  '[1,2,3]' "$got"
+
+# --- Test 17: find-overlap rejects malformed issues-json. -------------
+sandbox=$(with_sandbox); cleanup_dirs+=("$sandbox")
+export WORKFLOW_IMPLEMENT_STATE_DIR="$sandbox"
+set +e
+bash "$script" find-overlap acme/repo 'not-json' >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit_code "find-overlap rejects non-JSON input with exit 2" 2 "$rc"
+
+set +e
+bash "$script" find-overlap acme/repo '["a","b"]' >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit_code "find-overlap rejects non-numeric array with exit 2" 2 "$rc"
+
+# --- Test 18: find-overlap survives a corrupted neighbour state file. -
+# The intake-time scan must not be blocked by an unrelated corrupted
+# file — `--session list` is the surface that flags corruption to the
+# user, not this scan. A fresh run should still see the overlap from
+# every parseable peer.
+sandbox=$(with_sandbox); cleanup_dirs+=("$sandbox")
+export WORKFLOW_IMPLEMENT_STATE_DIR="$sandbox"
+run_init wfi-good acme/repo '[458]'
+printf '{ broken' > "$sandbox/wfi-bad.json"
+got=$(bash "$script" find-overlap acme/repo '[458]' \
+      | jq -c '[.[] | .session_id]')
+assert_eq "find-overlap skips corrupted state files without failing" \
+  '["wfi-good"]' "$got"
+
+# --- find-stale ------------------------------------------------------
+# Stale = every active issue (state ∈ scheduled | in-progress |
+# automerge_set) is CLOSED on GitHub per the supplied gh-state mapping.
+# The mapping is supplied by the orchestrator (it owns the network
+# calls) so this script stays offline-by-default and unit-testable.
+
+# --- Test 19: find-stale on empty state directory returns []. --------
+sandbox=$(with_sandbox); cleanup_dirs+=("$sandbox")
+export WORKFLOW_IMPLEMENT_STATE_DIR="$sandbox"
+got=$(echo '{}' | bash "$script" find-stale - | jq -c '.')
+assert_eq "find-stale on empty state dir returns []" '[]' "$got"
+
+# --- Test 20: find-stale detects a session whose every active issue is
+#              CLOSED on GitHub. -------------------------------------
+sandbox=$(with_sandbox); cleanup_dirs+=("$sandbox")
+export WORKFLOW_IMPLEMENT_STATE_DIR="$sandbox"
+run_init wfi-stale acme/repo '[458]'
+bash "$script" update-issue wfi-stale 458 in-progress >/dev/null
+got=$(echo '{"458":"CLOSED"}' \
+      | bash "$script" find-stale acme/repo - \
+      | jq -c '[.[] | .session_id]')
+assert_eq "find-stale flags a session whose only active issue is CLOSED" \
+  '["wfi-stale"]' "$got"
+
+# --- Test 21: find-stale ignores sessions with at least one OPEN
+#              active issue. ----------------------------------------
+sandbox=$(with_sandbox); cleanup_dirs+=("$sandbox")
+export WORKFLOW_IMPLEMENT_STATE_DIR="$sandbox"
+run_init wfi-not-stale acme/repo '[458,459]'
+bash "$script" update-issue wfi-not-stale 458 in-progress >/dev/null
+bash "$script" update-issue wfi-not-stale 459 scheduled   >/dev/null
+got=$(echo '{"458":"CLOSED","459":"OPEN"}' \
+      | bash "$script" find-stale acme/repo - \
+      | jq -c '.')
+assert_eq "find-stale ignores sessions with at least one OPEN active issue" \
+  '[]' "$got"
+
+# --- Test 22: find-stale ignores sessions with no active issues at all
+#              (every issue terminal — Phase 8 GC will pick them up). -
+sandbox=$(with_sandbox); cleanup_dirs+=("$sandbox")
+export WORKFLOW_IMPLEMENT_STATE_DIR="$sandbox"
+run_init wfi-all-merged acme/repo '[458]'
+bash "$script" update-issue wfi-all-merged 458 merged >/dev/null
+got=$(echo '{}' \
+      | bash "$script" find-stale acme/repo - \
+      | jq -c '.')
+assert_eq "find-stale ignores sessions with no active issues" '[]' "$got"
+
+# --- Test 23: find-stale defaults missing gh-state entries to OPEN. --
+# An active issue not present in the mapping is conservatively treated
+# as still-open; the orchestrator sometimes batch-fetches a subset of
+# the relevant issues, and stale-marking on missing data would surface
+# false positives.
+sandbox=$(with_sandbox); cleanup_dirs+=("$sandbox")
+export WORKFLOW_IMPLEMENT_STATE_DIR="$sandbox"
+run_init wfi-conservative acme/repo '[458]'
+bash "$script" update-issue wfi-conservative 458 in-progress >/dev/null
+got=$(echo '{}' \
+      | bash "$script" find-stale acme/repo - \
+      | jq -c '.')
+assert_eq "find-stale treats missing gh-state entries as OPEN (not stale)" \
+  '[]' "$got"
+
+# --- Test 24: find-stale repo filter restricts the scan. -------------
+sandbox=$(with_sandbox); cleanup_dirs+=("$sandbox")
+export WORKFLOW_IMPLEMENT_STATE_DIR="$sandbox"
+run_init wfi-acme acme/repo '[458]'
+bash "$script" update-issue wfi-acme 458 in-progress >/dev/null
+run_init wfi-other other/repo '[100]'
+bash "$script" update-issue wfi-other 100 in-progress >/dev/null
+got=$(echo '{"458":"CLOSED","100":"CLOSED"}' \
+      | bash "$script" find-stale acme/repo - \
+      | jq -c '[.[] | .session_id]')
+assert_eq "find-stale repo filter restricts the scan to the named repo" \
+  '["wfi-acme"]' "$got"
+
+# Without the filter, both sessions are surfaced.
+got=$(echo '{"458":"CLOSED","100":"CLOSED"}' \
+      | bash "$script" find-stale - \
+      | jq -c '[.[] | .session_id] | sort')
+assert_eq "find-stale without repo filter surfaces every stale session" \
+  '["wfi-acme","wfi-other"]' "$got"
+
+# --- Test 25: find-stale reads the gh-state from a file path. --------
+sandbox=$(with_sandbox); cleanup_dirs+=("$sandbox")
+export WORKFLOW_IMPLEMENT_STATE_DIR="$sandbox"
+run_init wfi-from-file acme/repo '[458]'
+bash "$script" update-issue wfi-from-file 458 in-progress >/dev/null
+gh_state_path="$sandbox/gh-state.json"
+printf '%s' '{"458":"CLOSED"}' > "$gh_state_path"
+got=$(bash "$script" find-stale acme/repo "$gh_state_path" \
+      | jq -c '[.[] | .session_id]')
+assert_eq "find-stale reads gh-state from a file path" \
+  '["wfi-from-file"]' "$got"
+
+# --- Test 26: find-stale rejects a non-existent file path. -----------
+sandbox=$(with_sandbox); cleanup_dirs+=("$sandbox")
+export WORKFLOW_IMPLEMENT_STATE_DIR="$sandbox"
+set +e
+bash "$script" find-stale acme/repo /tmp/definitely-not-here-$$ \
+  >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit_code "find-stale exits 2 on missing gh-state file" 2 "$rc"
+
+# --- Test 27: find-stale rejects malformed gh-state. -----------------
+sandbox=$(with_sandbox); cleanup_dirs+=("$sandbox")
+export WORKFLOW_IMPLEMENT_STATE_DIR="$sandbox"
+set +e
+echo '[]' | bash "$script" find-stale - >/dev/null 2>&1
+rc=$?
+set -e
+assert_exit_code "find-stale exits 2 on non-object gh-state" 2 "$rc"
 
 if (( failed != 0 )); then
   printf '\nFAIL: one or more assertions failed.\n' >&2

--- a/plugins/workflow/skills/implement/scripts/tests/test-session-state.sh
+++ b/plugins/workflow/skills/implement/scripts/tests/test-session-state.sh
@@ -252,6 +252,25 @@ got=$(bash "$script" find-overlap acme/repo '[458]' --except wfi-self \
 assert_eq "find-overlap --except skips the named session" \
   '["wfi-other"]' "$got"
 
+# --- Test 15b: find-overlap accepts repeated --except for stale-pruning.
+# AC #4 of #104 is explicit that stale sessions are NOT counted as
+# active overlap. The orchestrator runs `find-stale` first, then passes
+# every stale session ID alongside its own session ID via repeated
+# `--except` flags. Without this, a dead session whose state file still
+# carries `state ∈ scheduled|in-progress|automerge_set` would surface as
+# a concurrency conflict and trigger a false-positive bail prompt — the
+# precise false positive AC #4 was written to exclude.
+sandbox=$(with_sandbox); cleanup_dirs+=("$sandbox")
+export WORKFLOW_IMPLEMENT_STATE_DIR="$sandbox"
+run_init wfi-caller acme/repo '[458]'
+run_init wfi-stale-peer acme/repo '[458]'
+run_init wfi-live-peer acme/repo '[458]'
+got=$(bash "$script" find-overlap acme/repo '[458]' \
+        --except wfi-caller --except wfi-stale-peer \
+      | jq -c '[.[] | .session_id]')
+assert_eq "find-overlap --except is repeatable for stale-peer pruning" \
+  '["wfi-live-peer"]' "$got"
+
 # --- Test 16: find-overlap excludes terminal / parked states. ---------
 # Active set = scheduled | in-progress | automerge_set. The other
 # possibilities (merged | blocked | paused | errored | externally_closed)


### PR DESCRIPTION
## Summary

- Two `/workflow:implement` sessions running against the same repo can
  silently race the same issue — the 2026-05-01 reproduction on
  `aidanns/agent-auth` #458 (one session orchestrating the milestone-7
  batch with a clarified architectural decision; a second independently
  merging a divergent design) is the concrete failure mode this guard
  prevents. Architecturally inconsistent merges land in `main` with no
  signal.
- Adds two new `session-state.sh` subcommands — `find-overlap` and
  `find-stale` — and wires them into Phase 1.1 of SKILL.md as a
  Phase-2-style batched-message prompt with a `--force` escape hatch
  named in the issue's AC.
- Stale-session detection (every active issue CLOSED on GitHub) is
  surfaced with a copy-pasteable `delete` invocation; the script never
  auto-deletes (state file deletion is irrecoverable).
- The "Out of scope (future)" paragraph in § Session lifecycle is
  promoted to a brief "Implemented in #104" reference.

## Decisions

- **Active-state filter is `scheduled | in-progress | automerge_set`,
  not the full state set.** A peer that is `blocked` / `paused` is alive
  in the user's mental model but doesn't hold an active dispatch — a
  fresh run can pick the issue up safely. The overlap that matters is
  "two implementing agents racing the same PR," not "the same issue
  number lives in two state files."
- **`find-stale` takes the GitHub-state mapping as input rather than
  calling `gh issue view` itself.** Keeps `session-state.sh` offline-by-
  default and trivially unit-testable. The orchestrator owns the network
  calls (it already has rate-limiting / auth context); the SKILL.md
  prose shows the wiring.
- **Default behaviour on overlap is bail; `--force` proceeds without
  asking.** The interactive prompt accepts `continue` / `hand off` /
  `skip <issue#>`. `--force` is the explicit "I've already reviewed
  `--session list`" escape hatch — typically used when the prior session
  crashed without cleanup and the user is resuming the same logical
  work.
- **Corrupted neighbour state files are silently skipped during the
  scan.** `cmd_list` already flags corruption to the user via the
  `(corrupted — see § Session state recovery)` annotation; a corrupted
  unrelated file shouldn't block a fresh intake's overlap check.

## Test plan

- [ ] `bash plugins/workflow/skills/implement/scripts/tests/test-session-state.sh`
      — all 32 assertions pass, including the 20 new `find-overlap` /
      `find-stale` cases.
- [ ] `shellcheck plugins/workflow/skills/implement/scripts/session-state.sh
      plugins/workflow/skills/implement/scripts/tests/test-session-state.sh`
      — exits clean.
- [ ] Manual smoke: create two state files in
      `~/.claude/state/workflow-implement/` with overlapping `issues`
      maps; run `bash session-state.sh find-overlap <repo> '[<n>]'`;
      verify the JSON output names both peers.
- [ ] Manual smoke: feed `find-stale` a mapping that closes every
      active issue of a state file; verify the file is surfaced. Then
      flip one issue to `OPEN`; verify it no longer is.
- [ ] Re-read SKILL.md § Phase 1.1 § Concurrency guard end-to-end and
      confirm the prose flows (no orphan headings, no broken refs).
- [ ] Re-read § Session lifecycle and confirm the "Out of scope
      (future)" promotion reads cleanly with the existing context.

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)