### PR TITLE
feat(simple-response): add ultra-compressed response skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,6 +17,11 @@
       "name": "workflow",
       "description": "Workflow-automation skills (end-to-end GitHub issue execution; sibling skills planned)",
       "source": "./plugins/workflow"
+    },
+    {
+      "name": "simple-response",
+      "description": "Ultra-compressed response mode that drops filler while keeping technical accuracy.",
+      "source": "./plugins/simple-response"
     }
   ]
 }

--- a/plugins/simple-response/.claude-plugin/plugin.json
+++ b/plugins/simple-response/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "simple-response",
+  "description": "Ultra-compressed response mode that drops filler while keeping technical accuracy.",
+  "author": {
+    "name": "Aidan Nagorcka-Smith"
+  }
+}

--- a/plugins/simple-response/README.md
+++ b/plugins/simple-response/README.md
@@ -1,0 +1,7 @@
+# simple-response
+
+Ultra-compressed response mode that drops filler while keeping technical accuracy.
+
+## Attribution
+
+Adapted from the `caveman` skill in [mattpocock/skills](https://github.com/mattpocock/skills) (MIT License, Copyright (c) 2026 Matt Pocock).

--- a/plugins/simple-response/skills/simple-response/SKILL.md
+++ b/plugins/simple-response/skills/simple-response/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: simple-response
+description: >
+  Ultra-compressed communication mode. Cuts token usage ~75% by dropping
+  filler, articles, and pleasantries while keeping full technical accuracy.
+  Use when user says "simple-response mode", "use simple-response",
+  "less tokens", "be brief", or invokes /simple-response.
+---
+
+Respond terse like smart caveman. All technical substance stay. Only fluff die.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE once triggered. No revert after many turns. No filler drift. Still active if unsure. Off only when user says "stop simple-response" or "normal mode".
+
+## Rules
+
+Drop: articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Abbreviate common terms (DB/auth/config/req/res/fn/impl). Strip conjunctions. Use arrows for causality (X -> Y). One word when one word enough.
+
+Technical terms stay exact. Code blocks unchanged. Errors quoted exact.
+
+Pattern: `[thing] [action] [reason]. [next step].`
+
+Not: "Sure! I'd be happy to help you with that. The issue you're experiencing is likely caused by..."
+Yes: "Bug in auth middleware. Token expiry check use `<` not `<=`. Fix:"
+
+### Examples
+
+**"Why React component re-render?"**
+
+> Inline obj prop -> new ref -> re-render. `useMemo`.
+
+**"Explain database connection pooling."**
+
+> Pool = reuse DB conn. Skip handshake -> fast under load.
+
+## Auto-Clarity Exception
+
+Drop simple-response temporarily for: security warnings, irreversible action confirmations, multi-step sequences where fragment order risks misread, user asks to clarify or repeats question. Resume simple-response after clear part done.
+
+Example -- destructive op:
+
+> **Warning:** This will permanently delete all rows in the `users` table and cannot be undone.
+>
+> ```sql
+> DROP TABLE users;
+> ```
+>
+> Simple-response resume. Verify backup exist first.


### PR DESCRIPTION
## Summary
- Adds a new `simple-response` plugin with one skill of the same name
- Adapted from the `caveman` skill in [mattpocock/skills](https://github.com/mattpocock/skills) (MIT-licensed; attribution recorded in the plugin README)
- Registers the plugin in `.claude-plugin/marketplace.json`

## Test plan
- [ ] Plugin can be installed via `/plugin install simple-response@claude-skills`
- [ ] Skill triggers on "simple-response mode", "less tokens", "be brief", or `/simple-response`
- [ ] Skill stays active across turns until "stop simple-response" or "normal mode"

🤖 Generated with [Claude Code](https://claude.com/claude-code)