### PR TITLE
docs: scaffold engineering-skills agent context

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,3 +14,17 @@ Personal Claude Code plugin marketplace hosted on GitHub as `aidanns/claude-skil
 - Each plugin must have a `.claude-plugin/plugin.json` with at minimum `name`, `description`, and `author` fields.
 - Skills go in `skills/<skill-name>/SKILL.md` within the plugin directory.
 - Follow the official plugin structure documented in `claude-plugins-official`.
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues for `aidanns/claude-skills` (use the `gh` CLI). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical triage roles (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) map 1:1 to label strings of the same name. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root (created lazily by `/grill-with-docs`). See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,38 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context layout:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-some-decision.md
+│   └── 0002-another-decision.md
+├── plugins/
+└── external_plugins/
+```
+
+If this repo ever needs multiple contexts (e.g. distinct domains under one root), re-run `/setup` to switch the layout.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,11 @@
+# Triage Labels
+
+The `engineering:triage` skill speaks in terms of five canonical triage roles. In this repo, every role is mapped to a label string of the same name:
+
+- `needs-triage` — maintainer needs to evaluate this issue
+- `needs-info` — waiting on reporter for more information
+- `ready-for-agent` — fully specified, ready for an AFK agent
+- `ready-for-human` — requires human implementation
+- `wontfix` — will not be actioned
+
+When a skill mentions a role, apply the matching label.


### PR DESCRIPTION
## Summary

- Adds the `## Agent skills` block to `CLAUDE.md` so the `engineering` plugin's skills (triage, to-issues, diagnose, etc.) know where to look for repo-specific context.
- Creates three new files under `docs/agents/` populated from the `engineering:setup` skill's seed templates and adapted to this repo:
  - `issue-tracker.md` — GitHub via `gh` (verbatim from seed; this repo really is on GitHub).
  - `triage-labels.md` — five canonical triage roles, all mapped 1:1 to label strings of the same name.
  - `domain.md` — single-context layout with this repo's actual top-level dirs (`plugins/` / `external_plugins/`); multi-context section trimmed since it isn't applicable.

## Side effects landed earlier (not in this PR's diff)

- **Five GitHub labels** (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, plus the pre-existing `wontfix`) were created via `gh label create` so `engineering:triage` has labels to apply.
- **Issue #114** was triaged through to `ready-for-agent` with an agent brief comment using the new label vocabulary.

These are remote-state changes, not file changes; they're noted here for the record.

## Deferred follow-ups

- **#116** — bare `/setup` / `/grill-with-docs` references in `docs/agents/domain.md` should be namespaced (`engineering:setup` / `engineering:grill-with-docs`), needs coordinated fix with upstream seed templates.

## Test plan

- [x] `cat CLAUDE.md` shows the new `## Agent skills` block at the bottom with three subsections referencing `docs/agents/*.md`.
- [x] `ls docs/agents/` lists `issue-tracker.md`, `triage-labels.md`, `domain.md`.
- [x] `gh label list --repo aidanns/claude-skills` shows all five canonical triage labels.
- [x] Each `docs/agents/*.md` file is internally consistent and aligned with the engineering plugin's skill files (`plugins/engineering/skills/{triage,setup}/SKILL.md`) — verified by independent review subagent.
- [x] No broken references — every link / relative path mentioned resolves — verified by independent review subagent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)