### PR TITLE
docs(engineering): namespace slash-command references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,4 +27,4 @@ Five canonical triage roles (`needs-triage`, `needs-info`, `ready-for-agent`, `r
 
 ### Domain docs
 
-Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root (created lazily by `/grill-with-docs`). See `docs/agents/domain.md`.
+Single-context: one `CONTEXT.md` + `docs/adr/` at the repo root (created lazily by `engineering:grill-with-docs`). See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -7,7 +7,7 @@ How the engineering skills should consume this repo's domain documentation when 
 - **`CONTEXT.md`** at the repo root.
 - **`docs/adr/`** — read ADRs that touch the area you're about to work in.
 
-If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`engineering:grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
 
 ## File structure
 
@@ -23,13 +23,13 @@ Single-context layout:
 └── external_plugins/
 ```
 
-If this repo ever needs multiple contexts (e.g. distinct domains under one root), re-run `/setup` to switch the layout.
+If this repo ever needs multiple contexts (e.g. distinct domains under one root), re-run `engineering:setup` to switch the layout.
 
 ## Use the glossary's vocabulary
 
 When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
 
-If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `engineering:grill-with-docs`).
 
 ## Flag ADR conflicts
 

--- a/plugins/engineering/README.md
+++ b/plugins/engineering/README.md
@@ -23,7 +23,7 @@ Several skills (`to-issues`, `to-prd`, `triage`, and indirectly `diagnose` / `td
 - An **issue tracker** (GitHub by default) and **triage label vocabulary** (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`).
 - A **domain glossary** at `CONTEXT.md` and **ADRs** under `docs/adr/`.
 
-Run `/setup` once per repo to scaffold these. The other skills will then read from `docs/agents/issue-tracker.md`, `docs/agents/triage-labels.md`, and `docs/agents/domain.md`.
+Run `engineering:setup` once per repo to scaffold these. The other skills will then read from `docs/agents/issue-tracker.md`, `docs/agents/triage-labels.md`, and `docs/agents/domain.md`.
 
 ## Attribution
 

--- a/plugins/engineering/skills/diagnose/SKILL.md
+++ b/plugins/engineering/skills/diagnose/SKILL.md
@@ -114,4 +114,4 @@ Required before declaring done:
 - [ ] Throwaway prototypes deleted (or moved to a clearly-marked debug location)
 - [ ] The hypothesis that turned out correct is stated in the commit / PR message — so the next debugger learns
 
-**Then ask: what would have prevented this bug?** If the answer involves architectural change (no good test seam, tangled callers, hidden coupling) hand off to the `/improve-codebase-architecture` skill with the specifics. Make the recommendation **after** the fix is in, not before — you have more information now than when you started.
+**Then ask: what would have prevented this bug?** If the answer involves architectural change (no good test seam, tangled callers, hidden coupling) hand off to the `engineering:improve-codebase-architecture` skill with the specifics. Make the recommendation **after** the fix is in, not before — you have more information now than when you started.

--- a/plugins/engineering/skills/improve-codebase-architecture/SKILL.md
+++ b/plugins/engineering/skills/improve-codebase-architecture/SKILL.md
@@ -65,7 +65,7 @@ Once the user picks a candidate, drop into a grilling conversation. Walk the des
 
 Side effects happen inline as decisions crystallize:
 
-- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` — same discipline as `/grill-with-docs` (see [CONTEXT-FORMAT.md](../grill-with-docs/CONTEXT-FORMAT.md)). Create the file lazily if it doesn't exist.
+- **Naming a deepened module after a concept not in `CONTEXT.md`?** Add the term to `CONTEXT.md` — same discipline as `engineering:grill-with-docs` (see [CONTEXT-FORMAT.md](../grill-with-docs/CONTEXT-FORMAT.md)). Create the file lazily if it doesn't exist.
 - **Sharpening a fuzzy term during the conversation?** Update `CONTEXT.md` right there.
 - **User rejects the candidate with a load-bearing reason?** Offer an ADR, framed as: _"Want me to record this as an ADR so future architecture reviews don't re-suggest it?"_ Only offer when the reason would actually be needed by a future explorer to avoid re-suggesting the same thing — skip ephemeral reasons ("not worth it right now") and self-evident ones. See [ADR-FORMAT.md](../grill-with-docs/ADR-FORMAT.md).
 - **Want to explore alternative interfaces for the deepened module?** See [INTERFACE-DESIGN.md](INTERFACE-DESIGN.md).

--- a/plugins/engineering/skills/setup/domain.md
+++ b/plugins/engineering/skills/setup/domain.md
@@ -8,7 +8,7 @@ How the engineering skills should consume this repo's domain documentation when 
 - **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
 - **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
 
-If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`engineering:grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
 
 ## File structure
 
@@ -42,7 +42,7 @@ Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
 
 When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
 
-If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `engineering:grill-with-docs`).
 
 ## Flag ADR conflicts
 

--- a/plugins/engineering/skills/to-issues/SKILL.md
+++ b/plugins/engineering/skills/to-issues/SKILL.md
@@ -7,7 +7,7 @@ description: Break a plan, spec, or PRD into independently-grabbable issues on t
 
 Break a plan into independently-grabbable issues using vertical slices (tracer bullets).
 
-The issue tracker and triage label vocabulary should have been provided to you — run `/setup` if not.
+The issue tracker and triage label vocabulary should have been provided to you — run `engineering:setup` if not.
 
 ## Process
 

--- a/plugins/engineering/skills/to-prd/SKILL.md
+++ b/plugins/engineering/skills/to-prd/SKILL.md
@@ -5,7 +5,7 @@ description: Turn the current conversation context into a PRD and publish it to 
 
 This skill takes the current conversation context and codebase understanding and produces a PRD. Do NOT interview the user — just synthesize what you already know.
 
-The issue tracker and triage label vocabulary should have been provided to you — run `/setup` if not.
+The issue tracker and triage label vocabulary should have been provided to you — run `engineering:setup` if not.
 
 ## Process
 

--- a/plugins/engineering/skills/triage/AGENT-BRIEF.md
+++ b/plugins/engineering/skills/triage/AGENT-BRIEF.md
@@ -20,7 +20,7 @@ Describe **what** the system should do, not **how** to implement it. The agent w
 
 - **Good:** "The `SkillConfig` type should accept an optional `schedule` field of type `CronExpression`"
 - **Bad:** "Open src/types/skill.ts and add a schedule field on line 42"
-- **Good:** "When a user runs `/triage` with no arguments, they should see a summary of issues needing attention"
+- **Good:** "When a user runs `engineering:triage` with no arguments, they should see a summary of issues needing attention"
 - **Bad:** "Add a switch statement in the main handler function"
 
 ### Complete acceptance criteria

--- a/plugins/engineering/skills/triage/SKILL.md
+++ b/plugins/engineering/skills/triage/SKILL.md
@@ -35,13 +35,13 @@ Five **state** roles:
 
 Every triaged issue should carry exactly one category role and one state role. If state roles conflict, flag it and ask the maintainer before doing anything else.
 
-These are canonical role names — the actual label strings used in the issue tracker may differ. The mapping should have been provided to you - run `/setup` if not.
+These are canonical role names — the actual label strings used in the issue tracker may differ. The mapping should have been provided to you - run `engineering:setup` if not.
 
 State transitions: an unlabeled issue normally goes to `needs-triage` first; from there it moves to `needs-info`, `ready-for-agent`, `ready-for-human`, or `wontfix`. `needs-info` returns to `needs-triage` once the reporter replies. The maintainer can override at any time — flag transitions that look unusual and ask before proceeding.
 
 ## Invocation
 
-The maintainer invokes `/triage` and describes what they want in natural language. Interpret the request and act. Examples:
+The maintainer invokes `engineering:triage` and describes what they want in natural language. Interpret the request and act. Examples:
 
 - "Show me anything that needs my attention"
 - "Let's look at #42"
@@ -66,7 +66,7 @@ Show counts and a one-line summary per issue. Let the maintainer pick.
 
 3. **Reproduce (bugs only).** Before any grilling, attempt reproduction: read the reporter's steps, trace the relevant code, run tests or commands. Report what happened — successful repro with code path, failed repro, or insufficient detail (a strong `needs-info` signal). A confirmed repro makes a much stronger agent brief.
 
-4. **Grill (if needed).** If the issue needs fleshing out, run a `/grill-with-docs` session.
+4. **Grill (if needed).** If the issue needs fleshing out, run an `engineering:grill-with-docs` session.
 
 5. **Apply the outcome:**
    - `ready-for-agent` — post an agent brief comment ([AGENT-BRIEF.md](AGENT-BRIEF.md)).


### PR DESCRIPTION
## Summary

Replaces bare backtick-bounded slash-command refs with their plugin-namespaced form across this repo's engineering-plugin docs and skill files.

- `` `/setup` `` → `` `engineering:setup` `` (×6 sites)
- `` `/grill-with-docs` `` → `` `engineering:grill-with-docs` `` (×7 sites)
- `` `/triage` `` → `` `engineering:triage` `` (×2 sites)
- `` `/improve-codebase-architecture` `` → `` `engineering:improve-codebase-architecture` `` (×1 site)

Plus one grammatical fix: `a` → `an` in `plugins/engineering/skills/triage/SKILL.md` line 69, where the new vowel-starting word follows.

The `engineering:setup` skill's own seed templates (`plugins/engineering/skills/setup/domain.md`) are part of the rename, so re-running the skill in any repo will produce the namespaced form going forward.

Closes #116.

## Files touched (10)

- `CLAUDE.md` (1 site)
- `docs/agents/domain.md` (3 sites)
- `plugins/engineering/README.md` (1 site)
- `plugins/engineering/skills/diagnose/SKILL.md` (1 site)
- `plugins/engineering/skills/improve-codebase-architecture/SKILL.md` (1 site)
- `plugins/engineering/skills/setup/domain.md` (2 sites)
- `plugins/engineering/skills/to-issues/SKILL.md` (1 site)
- `plugins/engineering/skills/to-prd/SKILL.md` (1 site)
- `plugins/engineering/skills/triage/AGENT-BRIEF.md` (1 site)
- `plugins/engineering/skills/triage/SKILL.md` (3 sites + grammar fix)

## Test plan

- [x] `grep -rEn '\`/(setup|grill-with-docs|triage|diagnose|tdd|improve-codebase-architecture|zoom-out|to-prd|to-issues)\`' CLAUDE.md README.md docs/ plugins/` returns zero matches.
- [x] `grep -rEn '\bA \`engineering:' . --include='*.md'` returns zero matches (no `a` / `an` mismatches).
- [x] Each renamed reference points at a real skill directory under `plugins/engineering/skills/`.
- [x] `plugins/engineering/skills/setup/domain.md` (the seed) uses the namespaced form, so re-running `engineering:setup` would write the namespaced form into a fresh `docs/agents/domain.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)