### PR TITLE
fix(workflow): resolve nameWithOwner before cd into tmpdir

### DIFF
--- a/plugins/workflow/skills/implement/scripts/monitor-behind-resolve.sh
+++ b/plugins/workflow/skills/implement/scripts/monitor-behind-resolve.sh
@@ -132,15 +132,20 @@ fi
 # back to the caller. The dedupe file lives outside the subshell (passed by
 # path), so writes survive subshell teardown.
 (
+  # Resolve the target repo's `nameWithOwner` BEFORE `cd`-ing into the
+  # tempdir. `gh repo view` with no `--repo` flag derives the target from
+  # the cwd's git remote; the caller's cwd is the orchestrator's session
+  # checkout (a real git repo), but the tempdir below is empty and not a
+  # git repo, so the call must happen here. A failure (transient gh /
+  # network issue, cwd somehow not in a repo) defers silently to the next
+  # tick rather than corrupting the clone arg with the error message.
+  nwo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) || exit 0
+
   tmpdir=$(mktemp -d)
   trap 'rm -rf "$tmpdir"' EXIT
   cd "$tmpdir" || exit 0
 
-  # Clone. `gh repo view` is inside the substitution -- if it fails the clone
-  # will too, so capturing the clone failure subsumes both cases.
-  clone_err=$(gh repo clone \
-    "$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1)" \
-    repo -- --branch "$branch" --depth 50 2>&1 >/dev/null)
+  clone_err=$(gh repo clone "$nwo" repo -- --branch "$branch" --depth 50 2>&1 >/dev/null)
   clone_rc=$?
   if [[ $clone_rc -ne 0 ]]; then
     emit_degraded_once clone "$clone_err"

--- a/plugins/workflow/skills/implement/scripts/tests/test-monitor-behind-resolve.sh
+++ b/plugins/workflow/skills/implement/scripts/tests/test-monitor-behind-resolve.sh
@@ -111,6 +111,20 @@ case "$1 $2" in
       printf 'gh repo view: rate-limited\n' >&2
       exit 1
     fi
+    # Issue #111 regression: when `view_requires_git_cwd` is set, mirror
+    # real `gh repo view`'s behaviour of deriving the target from the
+    # cwd's git remote -- fail with the canonical "not a git repository"
+    # error if the cwd is not inside a git repo. This catches a regression
+    # where the helper invokes `gh repo view` from inside the empty
+    # tempdir (not a git repo) instead of from the caller's cwd.
+    if [[ "$(cat "${state_dir}/view_requires_git_cwd" 2>/dev/null || echo no)" == "yes" ]]; then
+      # `git rev-parse --git-dir` falls through to the real git binary
+      # via the sibling git-stub's `*)` case.
+      if ! git rev-parse --git-dir >/dev/null 2>&1; then
+        printf 'failed to run git: fatal: not a git repository (or any of the parent directories): .git\n' >&2
+        exit 1
+      fi
+    fi
     printf 'owner/repo\n'
     ;;
   "repo clone")
@@ -331,22 +345,27 @@ assert_not_contains "push failure does NOT emit MONITOR_DEGRADED" \
   "MONITOR_DEGRADED" "$out"
 rm -rf "$sandbox"
 
-# --- Test 8: `gh repo view` failure surfaces as MONITOR_DEGRADED clone.
-# Pins the design decision documented in the PR body: `gh repo view` is
-# folded into the `clone` step because the view call is an argument
-# substitution to clone -- if view fails the clone arg is corrupt and the
-# clone fails, capturing both. `clone_mode=ok` here so the clone-stub-side
-# explicit-fail path is NOT what surfaces the failure -- it has to come
-# from the view-corrupted repo arg flowing into the clone.
+# --- Test 8 (issue #111): a `gh repo view` failure defers silently.
+# The helper resolves `nameWithOwner` from the caller's cwd BEFORE `cd`-ing
+# into the tempdir (which is empty / not a git repo and would deterministically
+# fail the view). A genuine `gh repo view` failure (transient gh, network
+# blip, caller cwd somehow not in a repo) must exit silently to defer to the
+# next tick — same pattern as the CI-not-fully-green precheck — rather than
+# emitting a misleading MONITOR_DEGRADED clone event whose reason text is
+# the `gh repo view` error.
+#
+# This test also pins the deduplication-side contract: a transient view
+# failure must not consume the `clone:<pr>` dedupe slot, so a real later
+# clone failure for the same PR can still surface.
 sandbox=$(make_sandbox)
 dedupe="$sandbox/dedupe"; : >"$dedupe"
 printf 'fail\n' >"$sandbox/state/view_mode"
 out=$(run_helper "$sandbox" 951 feature/v main "$dedupe" 2>&1)
 
-assert_contains "gh repo view failure surfaces as MONITOR_DEGRADED clone" \
-  "MONITOR_DEGRADED 951 clone" "$out"
-assert_contains "view-via-clone failure reason carries the clone-side stderr" \
-  "invalid repository" "$out"
+assert_eq "gh repo view failure defers silently (no event emitted)" \
+  "" "$out"
+assert_eq "gh repo view failure leaves dedupe file untouched" \
+  "" "$(cat "$dedupe")"
 rm -rf "$sandbox"
 
 # --- Test 9 (issue #100): CI-pending precheck defers the resolve.
@@ -416,6 +435,44 @@ out=$(run_helper "$sandbox" 1005 feature/g main "$dedupe" 2>&1)
 
 assert_eq "transient gh failure on precheck defers silently" \
   "" "$out"
+rm -rf "$sandbox"
+
+# --- Test 14 (issue #111): the helper resolves `nameWithOwner` from the
+# caller's cwd (a real git repo), not from the empty tempdir it `cd`s into.
+#
+# Symptom guarded against: `gh repo view` with no `--repo` flag derives
+# the target from the cwd's git remote. If the helper invokes it from
+# inside the freshly-`mktemp -d`'d tmpdir, the call deterministically
+# fails with "not a git repository", the substituted-into-clone-arg
+# becomes the error message, the clone fails, and a `MONITOR_DEGRADED
+# clone` event fires on every BEHIND tick — never resolving.
+#
+# Test design: the gh stub's `repo view` branch checks for a `.git`
+# directory in its cwd when `view_requires_git_cwd` is set, mirroring
+# real `gh repo view`'s cwd-derived behaviour. We run the helper from
+# a git-repo cwd (the sandbox dir, after `git init`). On the buggy code
+# (`gh repo view` runs after `cd "$tmpdir"`, where there's no .git), the
+# stub fails and the test sees `MONITOR_DEGRADED clone`. On the fixed
+# code (`gh repo view` runs before the `cd`), the stub succeeds and the
+# test sees `BEHIND_RESOLVED 1006`.
+sandbox=$(make_sandbox)
+dedupe="$sandbox/dedupe"; : >"$dedupe"
+printf 'yes\n' >"$sandbox/state/view_requires_git_cwd"
+caller_cwd="$sandbox/caller-cwd"
+mkdir -p "$caller_cwd"
+( cd "$caller_cwd" && git init -q )
+out=$(
+  cd "$caller_cwd" && \
+    STATE_DIR="$sandbox/state" PATH="$sandbox/bin:$PATH" \
+    bash "$helper" 1006 feature/c main "$dedupe" 2>&1
+)
+
+assert_contains \
+  "gh repo view runs from caller's cwd (success path proceeds to BEHIND_RESOLVED)" \
+  "BEHIND_RESOLVED 1006" "$out"
+assert_not_contains \
+  "no MONITOR_DEGRADED clone leaks when caller cwd is a real git repo" \
+  "MONITOR_DEGRADED" "$out"
 rm -rf "$sandbox"
 
 if (( failed != 0 )); then


### PR DESCRIPTION
## Summary

`monitor-behind-resolve.sh` was emitting `MONITOR_DEGRADED 514 clone failed to run git: fatal: not a git repository...` on every BEHIND tick, and the auto-resolve never landed. Symptom: `/workflow:implement` runs that hit a `BEHIND` PR (e.g. session `wfi-2026-05-02-88ee` on `aidanns/agent-auth` PR #514) saw the same `MONITOR_DEGRADED clone` event each tick instead of `BEHIND_RESOLVED <pr#>`, forcing the merge-bot to do the catch-up itself.

**Cause.** `gh repo view` with no `--repo` flag derives its target from the cwd's git remote. The helper invoked it from inside the freshly-`mktemp -d`'d tmpdir (not a git repo), so `gh repo view` deterministically failed with `not a git repository`. The substituted-into-clone-arg then became the error message, the clone failed, and `MONITOR_DEGRADED clone` fired on every tick.

**Fix.** Capture `nameWithOwner` inside the subshell but **before** the `cd "$tmpdir"`, while the cwd is still the caller's git checkout (the orchestrator's session cwd). A genuine `gh repo view` failure (transient gh, network blip, caller cwd somehow not a repo) now defers silently to the next tick — matching the CI-not-fully-green precheck pattern — rather than corrupting the clone arg.

## Tests

- **Test 14 (new, regression)**: gh stub's `repo view` branch checks `git rev-parse --git-dir` in its cwd when `view_requires_git_cwd=yes`, mirroring real `gh repo view`'s cwd-derived behaviour. The helper is invoked from a real git-repo cwd. On the buggy code (view runs after the `cd`), the stub fails and the test sees `MONITOR_DEGRADED clone`. On the fixed code, the stub succeeds and the test sees `BEHIND_RESOLVED 1006`.
- **Test 8 (rewritten)**: previously pinned the now-obsolete "view-failure-folded-into-clone" contract. Now asserts the new contract: a `gh repo view` failure defers silently (no event emitted, dedupe file untouched so a real later clone failure for the same PR can still surface).

All 29 assertions in `test-monitor-behind-resolve.sh` pass; sibling tests (`test-phase15-conventions.sh`, `test-session-state.sh`) also still pass.

## Test plan

- [ ] `monitor-behind-resolve.sh` resolves `nameWithOwner` from the caller's cwd (a real git repo) before `cd`-ing into the tmpdir — verified by reading the diff and by Test 14.
- [ ] BEHIND auto-resolve completes successfully when only blocker is BEHIND — asserted by Test 14 emitting `BEHIND_RESOLVED 1006` not `MONITOR_DEGRADED clone`.
- [ ] Bash unit tests under `scripts/tests/` still pass (`bash plugins/workflow/skills/implement/scripts/tests/test-monitor-behind-resolve.sh`).

Closes #111